### PR TITLE
🔀 :: JwtTokenDTO API 명세서와 일치화

### DIFF
--- a/Projects/Domain/BaseDomain/Sources/Interceptors/Jwt/JwtTokenDTO.swift
+++ b/Projects/Domain/BaseDomain/Sources/Interceptors/Jwt/JwtTokenDTO.swift
@@ -3,4 +3,10 @@ struct JwtTokenDTO: Decodable {
     let refreshToken: String
     let accessExpiresAt: String
     let refreshExpiresAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken, refreshToken
+        case accessExpiresAt = "accessTokenExp"
+        case refreshExpiresAt = "refreshTokenExp"
+    }
 }


### PR DESCRIPTION
## 💡 개요
- JwtTokenDTO를 API 명세서의 필드로 받을 수 있게 바꿉니다

