### PR TITLE
🔀 :: SMSIcon의 renderingMode를 생성자로 받도록 변경

### DIFF
--- a/Projects/Core/DesignSystem/Sources/Icon/SMSIcon.swift
+++ b/Projects/Core/DesignSystem/Sources/Icon/SMSIcon.swift
@@ -2,15 +2,18 @@ import SwiftUI
 
 public struct SMSIcon: View {
     var icon: Icon
+    var renderingMode: Image.TemplateRenderingMode
     var width: CGFloat
     var height: CGFloat
 
     public init(
         _ icon: Icon,
+        renderingMode: Image.TemplateRenderingMode = .original,
         width: CGFloat = 24,
         height: CGFloat = 24
     ) {
         self.icon = icon
+        self.renderingMode = renderingMode
         self.width = width
         self.height = height
     }
@@ -28,6 +31,7 @@ public struct SMSIcon: View {
     public var body: some View {
         iconToImage()
             .resizable()
+            .renderingMode(renderingMode)
             .frame(width: width, height: height)
     }
 


### PR DESCRIPTION
## 💡 개요
SMSIcon을 사용할 때 생성자에서 renderingMode를 받습니다.

## 📃 작업내용
SMSIcon 생성자에 renderingMode 추가

## 🔀 변경사항
SMSIcon 생성자에 renderingMode 추가

## 🍴 사용방법
```swift
SMSIcon(.camera, renderingMode: .original)
```