### PR TITLE
🔀 :: smsBackButton modifier 추가

### DIFF
--- a/Projects/Core/DesignSystem/Demo/Sources/DemoView.swift
+++ b/Projects/Core/DesignSystem/Demo/Sources/DemoView.swift
@@ -12,12 +12,29 @@ struct DemoView: View {
                     .titleWrapper("비밀번호", position: .top(.trailing))
             }
             .padding(8)
+
+            NavigationLink {
+                AView()
+            } label: {
+                Text("A")
+            }
         }
+    }
+}
+
+struct AView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        Text("A")
+            .smsBackButton(dismiss: dismiss)
     }
 }
 
 struct DemoView_Previews: PreviewProvider {
     static var previews: some View {
-        DemoView()
+        NavigationView {
+            DemoView()
+        }
     }
 }

--- a/Projects/Core/DesignSystem/Sources/Extension/View+smsBackButton.swift
+++ b/Projects/Core/DesignSystem/Sources/Extension/View+smsBackButton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct SMSBackButtonModifier: ViewModifier {
+    let dismiss: DismissAction
+    let willDismiss: () -> Void
+
+    init(
+        dismiss: DismissAction,
+        willDismiss: @escaping () -> Void = {}
+    ) {
+        self.dismiss = dismiss
+        self.willDismiss = willDismiss
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarLeading) {
+                    Button {
+                        willDismiss()
+                        dismiss()
+                    } label: {
+                        SMSIcon(.leftArrow, width: 24, height: 24)
+                    }
+                }
+            }
+    }
+}
+
+public extension View {
+    func smsBackButton(
+        dismiss: DismissAction,
+        willDismiss: @escaping () -> Void = {}
+    ) -> some View {
+        self
+            .modifier(SMSBackButtonModifier(dismiss: dismiss, willDismiss: willDismiss))
+    }
+}
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
## 💡 개요
전체 화면에서 공통적으로 사용할 backButton modifier를 추가합니다

https://github.com/GSM-MSG/SMS-iOS/assets/74440939/460a06be-147a-4e8b-9cfa-6d99b0f1891e

## 🍴 사용방법
```swift
...
  .smsBackButton(dismiss: dismiss: willDismiss: { })
