### PR TITLE
🔀 :: 정보 입력 - 프로필 정보 입력 페이지의 타이틀 오타

### DIFF
--- a/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
+++ b/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
@@ -92,7 +92,7 @@ struct InputProfileInfoView: View {
     @ViewBuilder
     func pageTitleView() -> some View {
         HStack(spacing: 4) {
-            Text("학교 생활")
+            Text("프로필")
                 .foregroundColor(.sms(.system(.black)))
 
             Text("*")


### PR DESCRIPTION
## 💡 개요
프로필 정보를 입력할 때 타이틀이 '학교 생활' 인 오타를 수정


## 🔀 변경사항
프로필 정보를 입력할 때 타이틀이 '학교 생활' 인 오타를 '프로필'로 수정
