### PR TITLE
🔀 :: 입력 완료 후 홈으로 Root Scene 전환

### DIFF
--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -349,7 +349,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
 
 #if !NEEDLE_DYNAMIC
 
-private func register1() {
+@inline(never) private func register1() {
     registerProviderFactory("^->AppComponent->JwtStoreComponent", factoryb27d5aae1eb7e73575a6f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent", factoryEmptyDependencyProvider)
     registerProviderFactory("^->AppComponent->KeychainComponent", factoryEmptyDependencyProvider)

--- a/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
+++ b/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
@@ -51,6 +51,7 @@ struct InputCertificateInfoView: View {
                 .padding(.horizontal, 20)
             }
         }
+        .hideKeyboardWhenTap()
     }
 
     @ViewBuilder

--- a/Projects/Feature/InputInformationFeature/Interface/InputInformationBuildable.swift
+++ b/Projects/Feature/InputInformationFeature/Interface/InputInformationBuildable.swift
@@ -2,5 +2,5 @@ import SwiftUI
 
 public protocol InputInformationBuildable {
     associatedtype ViewType: View
-    func makeView() -> ViewType
+    func makeView(delegate: any InputInformationDelegate) -> ViewType
 }

--- a/Projects/Feature/InputInformationFeature/Interface/InputInformationDelegate.swift
+++ b/Projects/Feature/InputInformationFeature/Interface/InputInformationDelegate.swift
@@ -1,0 +1,3 @@
+public protocol InputInformationDelegate: AnyObject {
+    func completeToInputInformation()
+}

--- a/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
@@ -30,6 +30,7 @@ public final class InputInformationComponent:
         let model = InputInformationModel()
         let intent = InputInformationIntent(
             model: model,
+            inputInformationDelegate: delegate,
             dreamBookUploadUseCase: dependency.fileDomainBuildable.dreamBookUploadUseCase,
             imageUploadUseCase: dependency.fileDomainBuildable.imageUploadUseCase,
             inputInformationUseCase: dependency.studentDomainBuildable.inputInformationUseCase

--- a/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
@@ -26,7 +26,7 @@ public final class InputInformationComponent:
     Component<InputInformationDependency>,
     InputInformationBuildable {
 
-    public func makeView() -> some View {
+    public func makeView(delegate: any InputInformationDelegate) -> some View {
         let model = InputInformationModel()
         let intent = InputInformationIntent(
             model: model,

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -5,17 +5,20 @@ import InputProfileInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
 import InputLanguageInfoFeatureInterface
+import InputInformationFeatureInterface
 import StudentDomainInterface
 import FileDomainInterface
 
 final class InputInformationIntent: InputInformationIntentProtocol {
     private weak var model: (any InputInformationActionProtocol)?
+    private weak var inputInformationDelegate: (any InputInformationDelegate)?
     private let dreamBookUploadUseCase: any DreamBookUploadUseCase
     private let imageUploadUseCase: any ImageUploadUseCase
     private let inputInformationUseCase: any InputInformationUseCase
 
     init(
         model: any InputInformationActionProtocol,
+        inputInformationDelegate: any InputInformationDelegate,
         dreamBookUploadUseCase: any DreamBookUploadUseCase,
         imageUploadUseCase: any ImageUploadUseCase,
         inputInformationUseCase: any InputInformationUseCase

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -85,6 +85,7 @@ extension InputInformationIntent: InputSchoolLifeDelegate {
     }
 
     func completeToInputSchoolLife(input: InputSchoolLifeInformationObject) {
+        model?.updateInputSchoolLifeInformationObject(object: input)
         model?.nextButtonDidTap()
     }
 }

--- a/Projects/Feature/InputInformationFeature/Sources/Scene/InputInformationView.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Scene/InputInformationView.swift
@@ -71,7 +71,6 @@ struct InputInformationView: View {
                 .tag(InformationPhase.language)
         }
         .animation(.default, value: state.phase)
-        .ignoresSafeArea()
         .onChange(of: state.isCompleteToInputAllInfo) { newValue in
             if newValue {
                 intent.completeToInputAllInfo(state: state)

--- a/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
+++ b/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
@@ -42,6 +42,7 @@ struct InputLanguageInfoView: View {
                 .padding(.bottom, 32)
             }
         }
+        .hideKeyboardWhenTap()
     }
 
     @ViewBuilder

--- a/Projects/Feature/InputMilitaryInfoFeature/Sources/Scene/InputMilitaryInfoView.swift
+++ b/Projects/Feature/InputMilitaryInfoFeature/Sources/Scene/InputMilitaryInfoView.swift
@@ -57,6 +57,7 @@ struct InputMilitaryInfoView: View {
                 .padding([.top, .horizontal], 20)
             }
         }
+        .hideKeyboardWhenTap()
         .smsBottomSheet(
             isShowing: Binding(
                 get: { state.isPresentedMilitarySheet },

--- a/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
+++ b/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
@@ -78,11 +78,11 @@ struct InputProfileInfoView: View {
                             SMSIcon(.downChevron)
                                 .padding(.trailing, 12)
                         }
-                        .titleWrapper("분야")
                         .onTapGesture {
                             intent.majorSheetIsRequired()
                             intent.deActiveSelfEntering()
                         }
+                        .titleWrapper("분야")
 
                         SMSTextField(
                             "예시) https://github.com/",

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Intent/InputSchoolLifeInfoIntent.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Intent/InputSchoolLifeInfoIntent.swift
@@ -53,11 +53,14 @@ final class InputSchoolLifeInfoIntent: InputSchoolLifeInfoIntentProtocol {
         guard
             let gsmScore = Int(state.authenticationScore),
             let hwpURL = state.hwpFileURL,
+            hwpURL.startAccessingSecurityScopedResource(),
             let hwpData = try? Data(contentsOf: hwpURL),
             errorSet.isEmpty
         else {
+            state.hwpFileURL?.stopAccessingSecurityScopedResource()
             return
         }
+        hwpURL.stopAccessingSecurityScopedResource()
 
         let input = InputSchoolLifeInformationObject(
             hwpFilename: state.hwpFilename,

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Model/InputSchoolLifeInfoModel.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Model/InputSchoolLifeInfoModel.swift
@@ -32,6 +32,7 @@ extension InputSchoolLifeInfoModel: InputSchoolLifeInfoActionProtocol {
     }
 
     func updateHWPFileURL(url: URL) {
+        self.hwpFileURL?.stopAccessingSecurityScopedResource()
         self.hwpFileURL = url
     }
 

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
@@ -59,6 +59,7 @@ struct InputSchoolLifeInfoView: View {
                         CTAButton(text: "다음") {
                             intent.nextButtonDidTap(state: state)
                         }
+                        .disabled(state.isDisabledNextButton)
                         .frame(maxWidth: .infinity)
                     }
                     .padding(.bottom, 32)
@@ -66,6 +67,7 @@ struct InputSchoolLifeInfoView: View {
                 .padding([.top, .horizontal], 20)
             }
         }
+        .hideKeyboardWhenTap()
         .fileImporter(
             isPresented: Binding(
                 get: { state.isPresentedHWPFileImporter },
@@ -78,6 +80,7 @@ struct InputSchoolLifeInfoView: View {
         ) { result in
             switch result {
             case let .success(url):
+                guard url.startAccessingSecurityScopedResource() else { return }
                 intent.hwpFileDidSelect(url: url)
 
             case .failure:

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
@@ -80,7 +80,6 @@ struct InputSchoolLifeInfoView: View {
         ) { result in
             switch result {
             case let .success(url):
-                guard url.startAccessingSecurityScopedResource() else { return }
                 intent.hwpFileDidSelect(url: url)
 
             case .failure:

--- a/Projects/Feature/InputWorkInfoFeature/Sources/Scene/InputWorkInfoView.swift
+++ b/Projects/Feature/InputWorkInfoFeature/Sources/Scene/InputWorkInfoView.swift
@@ -77,6 +77,7 @@ struct InputWorkInfoView: View {
                 .padding(.horizontal, 20)
             }
         }
+        .hideKeyboardWhenTap()
         .smsBottomSheet(
             isShowing: Binding(
                 get: { state.isPresentedFormOfEmployeementSheet },

--- a/Projects/Feature/RootFeature/Sources/DI/RootComponent.swift
+++ b/Projects/Feature/RootFeature/Sources/DI/RootComponent.swift
@@ -12,7 +12,7 @@ public protocol RootDependency: Dependency {
 public final class RootComponent: Component<RootDependency> {
     public func makeView() -> some View {
         let model = RootModel()
-        let intent = RootIntent()
+        let intent = RootIntent(model: model)
         let container = MVIContainer(
             intent: intent as RootIntentProtocol,
             model: model as RootStateProtocol,

--- a/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
+++ b/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
@@ -5,6 +5,6 @@ final class RootIntent: RootIntentProtocol {}
 
 extension RootIntent: InputInformationDelegate {
     func completeToInputInformation() {
-        
+        print("SUC")
     }
 }

--- a/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
+++ b/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
@@ -1,10 +1,16 @@
 import Foundation
 import InputInformationFeatureInterface
 
-final class RootIntent: RootIntentProtocol {}
+final class RootIntent: RootIntentProtocol {
+    private weak var model: (any RootActionProtocol)?
+
+    init(model: any RootActionProtocol) {
+        self.model = model
+    }
+}
 
 extension RootIntent: InputInformationDelegate {
     func completeToInputInformation() {
-        print("SUC")
+        model?.updateSceneType(type: .home)
     }
 }

--- a/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
+++ b/Projects/Feature/RootFeature/Sources/Intent/RootIntent.swift
@@ -1,3 +1,10 @@
 import Foundation
+import InputInformationFeatureInterface
 
 final class RootIntent: RootIntentProtocol {}
+
+extension RootIntent: InputInformationDelegate {
+    func completeToInputInformation() {
+        
+    }
+}

--- a/Projects/Feature/RootFeature/Sources/Intent/RootIntentProtocol.swift
+++ b/Projects/Feature/RootFeature/Sources/Intent/RootIntentProtocol.swift
@@ -1,3 +1,4 @@
 import Foundation
+import InputInformationFeatureInterface
 
-protocol RootIntentProtocol {}
+protocol RootIntentProtocol: InputInformationDelegate {}

--- a/Projects/Feature/RootFeature/Sources/Model/RootModel.swift
+++ b/Projects/Feature/RootFeature/Sources/Model/RootModel.swift
@@ -4,4 +4,8 @@ final class RootModel: ObservableObject, RootStateProtocol {
     @Published var sceneType: RootSceneType = .inputInformation
 }
 
-extension RootModel: RootActionProtocol {}
+extension RootModel: RootActionProtocol {
+    func updateSceneType(type: RootSceneType) {
+        self.sceneType = type
+    }
+}

--- a/Projects/Feature/RootFeature/Sources/Model/RootModelProtocol.swift
+++ b/Projects/Feature/RootFeature/Sources/Model/RootModelProtocol.swift
@@ -4,4 +4,6 @@ protocol RootStateProtocol {
     var sceneType: RootSceneType { get }
 }
 
-protocol RootActionProtocol: AnyObject {}
+protocol RootActionProtocol: AnyObject {
+    func updateSceneType(type: RootSceneType)
+}

--- a/Projects/Feature/RootFeature/Sources/Scene/RootView.swift
+++ b/Projects/Feature/RootFeature/Sources/Scene/RootView.swift
@@ -33,7 +33,7 @@ struct RootView: View {
                 .eraseToAnyView()
 
         case .inputInformation:
-            inputInformationBuildable.makeView()
+            inputInformationBuildable.makeView(delegate: intent)
                 .eraseToAnyView()
         }
     }

--- a/Projects/Shared/ViewUtil/Sources/Extensions/View+hideKeyboard.swift
+++ b/Projects/Shared/ViewUtil/Sources/Extensions/View+hideKeyboard.swift
@@ -1,17 +1,31 @@
 import SwiftUI
+import UIKit
 
 public extension View {
     func hideKeyboardWhenTap() -> some View {
-        self
-            .onTapGesture(perform: hideKeyboard)
+        onAppear(perform: UIApplication.shared.hideKeyboard)
     }
+}
 
+public extension UIApplication {
     func hideKeyboard() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil,
-            from: nil,
-            for: nil
-        )
+        guard
+            let scene = connectedScenes.first as? UIWindowScene,
+            let window = scene.windows.first
+        else { return }
+        let tapRecognizer = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+        guard window.gestureRecognizers?.contains(where: { $0 == tapRecognizer }) == false else { return }
+        tapRecognizer.cancelsTouchesInView = false
+        tapRecognizer.delegate = self
+        window.addGestureRecognizer(tapRecognizer)
+    }
+}
+
+extension UIApplication: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        return false
     }
 }


### PR DESCRIPTION
## 💡 개요
정보 입력을 모두 완료하면 RootView의 SceneType을 홈으로 보냅니다

## 📃 작업내용
- 입력 완료 후 성공 시 RootView의 SceneType을 홈으로 보냄

## 🔀 변경사항
- keyboard의 를 무시하지 않게해서 TextField 입력할 때 이제 TextField가 키보드 위로 올라옵니다

