### PR TITLE
🔀 :: TextField의 에러가 활성화 될때 vmark의 위치가 이상해 지는 현상 해결

### DIFF
--- a/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
+++ b/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
@@ -89,9 +89,9 @@ struct InputProfileInfoView: View {
                         }
                         .focused($isFocuesedMajorTextField)
                         .disabled(!state.isSelfEntering)
-                        .overlay(alignment: .trailing) {
+                        .overlay(alignment: .topTrailing) {
                             SMSIcon(.downChevron)
-                                .padding(.trailing, 12)
+                                .padding([.top, .trailing], 12)
                         }
                         .onTapGesture {
                             intent.majorSheetIsRequired()


### PR DESCRIPTION
## 💡 개요
TextField의 에러가 활성화 될때 vmark의 위치가 이상해 지는 현상 해결

## 🔀 변경사항
vmark 이미지의 overlay alignment를 trailing에서 topTrailing으로 변경. padding을 trailing에서 top, trailing으로 변경