### PR TITLE
🔀 :: 자격증 페이지와 외국어 페이지에서 필수 표시(*)를 제거

### DIFF
--- a/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
+++ b/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
@@ -60,9 +60,6 @@ struct InputCertificateInfoView: View {
             Text("자격증")
                 .foregroundColor(.sms(.system(.black)))
 
-            Text("*")
-                .foregroundColor(.sms(.sub(.s2)))
-
             Spacer()
 
             SMSPageControl(pageCount: 6, selectedPage: 4)

--- a/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
+++ b/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
@@ -51,9 +51,6 @@ struct InputLanguageInfoView: View {
             Text("외국어")
                 .foregroundColor(.sms(.system(.black)))
 
-            Text("*")
-                .foregroundColor(.sms(.sub(.s2)))
-
             Spacer()
 
             SMSPageControl(pageCount: 6, selectedPage: 5)


### PR DESCRIPTION
## 💡 개요
자격증 페이지와 외국어 페이지에서 필수 표시(*)를 제거
