### PR TITLE
🔀 :: SwiftLint RunScript에서 warning뜨는 현상 해결

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Action+Template.swift
+++ b/Tuist/ProjectDescriptionHelpers/Action+Template.swift
@@ -3,7 +3,8 @@ import ProjectDescription
 public extension TargetScript {
     static let swiftLint = TargetScript.pre(
         path: Path.relativeToRoot("Scripts/SwiftLintRunScript.sh"),
-        name: "SwiftLint"
+        name: "SwiftLint",
+        basedOnDependencyAnalysis: false
     )
     static let needle = TargetScript.pre(
         path: .relativeToRoot("Scripts/NeedleRunScript.sh"),


### PR DESCRIPTION
## 💡 개요
SwiftLint를 RunScript로 돌릴 때 BasedOnDependency를 false로 해주지 않아 생긴 문제를 해결합니다.

