### PR TITLE
🔀 :: AuthDomainError를 API명세서와 동일하게 수정합니다

### DIFF
--- a/Projects/Domain/AuthDomain/Interface/Error/AuthDomainError.swift
+++ b/Projects/Domain/AuthDomain/Interface/Error/AuthDomainError.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 public enum AuthDomainError: Error {
-    case invalidGAuthCode
+    case failedToGAuthSignin
     case internalServerError
 }
 
 extension AuthDomainError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .invalidGAuthCode:
+        case .failedToGAuthSignin:
             return "GAuth 로그인에서 문제가 생겼습니다. 지속될 시 문의해주세요."
 
         case .internalServerError:

--- a/Projects/Domain/AuthDomain/Sources/Endpoint/AuthEndpoint.swift
+++ b/Projects/Domain/AuthDomain/Sources/Endpoint/AuthEndpoint.swift
@@ -43,6 +43,9 @@ extension AuthEndpoint: SMSEndpoint {
         switch self {
         case .signin:
             return [
+                400: .failedToGAuthSignin,
+                401: .failedToGAuthSignin,
+                404: .failedToGAuthSignin,
                 500: .internalServerError
             ]
         }

--- a/Projects/Domain/AuthDomain/Testing/DataSource/RemoteAuthDataSourceSpy.swift
+++ b/Projects/Domain/AuthDomain/Testing/DataSource/RemoteAuthDataSourceSpy.swift
@@ -5,7 +5,7 @@ final class RemoteAuthDataSourceSpy: RemoteAuthDataSource {
     func login(code: String) async throws -> IsAlreadySignUp {
         loginCallCount += 1
         if code.isEmpty {
-            throw AuthDomainError.invalidGAuthCode
+            throw AuthDomainError.failedToGAuthSignin
         }
         return true
     }

--- a/Projects/Domain/AuthDomain/Testing/Repository/AuthRepositorySpy.swift
+++ b/Projects/Domain/AuthDomain/Testing/Repository/AuthRepositorySpy.swift
@@ -5,7 +5,7 @@ final class AuthRepositorySpy: AuthRepository {
     func login(code: String) async throws -> IsAlreadySignUp {
         loginCallCount += 1
         if code.isEmpty {
-            throw AuthDomainError.invalidGAuthCode
+            throw AuthDomainError.failedToGAuthSignin
         }
         return true
     }

--- a/Projects/Domain/AuthDomain/Testing/UseCase/LoginUseCaseSpy.swift
+++ b/Projects/Domain/AuthDomain/Testing/UseCase/LoginUseCaseSpy.swift
@@ -5,7 +5,7 @@ final class LoginUseCaseSpy: LoginUseCase {
     func execute(code: String) async throws -> IsAlreadySignUp {
         callCount += 1
         if code.isEmpty {
-            throw AuthDomainError.invalidGAuthCode
+            throw AuthDomainError.failedToGAuthSignin
         }
         return true
     }

--- a/Projects/Domain/AuthDomain/Tests/Repository/AuthRepositorySpec.swift
+++ b/Projects/Domain/AuthDomain/Tests/Repository/AuthRepositorySpec.swift
@@ -17,9 +17,9 @@ final class AuthRepositorySpec: QuickSpec {
 
         describe("AuthRepositoryImpl에서") {
             context("code를 비운상태로 login을 실행하면") {
-                it("AuthDomainError.invalidGAuthCode error가 throw되고, loginCallCount가 +1 된다.") {
+                it("AuthDomainError.failedToGAuthSignin error가 throw되고, loginCallCount가 +1 된다.") {
                     await expect { try await authRepositoryImpl.login(code: "") }
-                        .to(throwError(AuthDomainError.invalidGAuthCode))
+                        .to(throwError(AuthDomainError.failedToGAuthSignin))
 
                     expect { remoteAuthDataSourceSpy.loginCallCount }
                         .to(equal(1))

--- a/Projects/Domain/AuthDomain/Tests/UseCase/LoginUseCaseSpec.swift
+++ b/Projects/Domain/AuthDomain/Tests/UseCase/LoginUseCaseSpec.swift
@@ -17,9 +17,9 @@ final class LoginUseCaseSpec: QuickSpec {
 
         describe("LoginUseCase에서") {
             context("code를 비운상태로 execute을 실행하면") {
-                it("AuthDomainError.invalidGAuthCode error가 throw되고, callCount가 +1 된다.") {
+                it("AuthDomainError.failedToGAuthSignin error가 throw되고, callCount가 +1 된다.") {
                     await expect { try await loginUseCase.execute(code: "") }
-                        .to(throwError(AuthDomainError.invalidGAuthCode))
+                        .to(throwError(AuthDomainError.failedToGAuthSignin))
 
                     expect { authRepositorySpy.loginCallCount }
                         .to(equal(1))


### PR DESCRIPTION
## 💡 개요
명세서에 맞게 400, 401, 404를 GAuth 로그인에서 실패한것으로 처리합니다.

## 📃 작업내용
- invalidGAuthCode 에러 -> failedToGAuthSignin 에러 로 이름 변경
- AuthEndpoint에서 400, 401, 404의 에러를 failedToGAuthSignin으로 설정