### PR TITLE
🔀 :: GAuth 환경 변수 이름 오타 수정

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -8,8 +8,8 @@
 	<string>Light</string>
 	<key>CLIENT_ID</key>
 	<string>$(CLIENT_ID)</string>
-	<key>REDIREDCT_URI</key>
-	<string>$(REDIREDCT_URI)</string>
+	<key>REDIRECT_URI</key>
+	<string>$(REDIRECT_URI)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Projects/Feature/SigninFeature/Sources/Scene/View/GAuthButtonView.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/View/GAuthButtonView.swift
@@ -18,10 +18,9 @@ struct GAuthButtonView: UIViewRepresentable {
         gauthButton.prepare(
             clientID: Bundle.main.object(forInfoDictionaryKey: "CLIENT_ID") as? String ?? "",
             redirectURI: Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URI") as? String ?? "",
-            presenting: topViewController
-        ) { code in
-            completion(code)
-        }
+            presenting: topViewController,
+            completion: completion
+        )
         return gauthButton
     }
 

--- a/Projects/Feature/SigninFeature/Sources/Scene/View/GAuthButtonView.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/View/GAuthButtonView.swift
@@ -17,7 +17,7 @@ struct GAuthButtonView: UIViewRepresentable {
         else { return gauthButton }
         gauthButton.prepare(
             clientID: Bundle.main.object(forInfoDictionaryKey: "CLIENT_ID") as? String ?? "",
-            redirectURI: Bundle.main.object(forInfoDictionaryKey: "REDIREDCT_URI") as? String ?? "",
+            redirectURI: Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URI") as? String ?? "",
             presenting: topViewController
         ) { code in
             completion(code)


### PR DESCRIPTION
## 💡 개요
- REDIREDCT_URI로 되어있는 이름을 REDIRECT_URI로 변경

## 📃 작업내용
- GAuthButtonView에서 REDIREDCT_URI 를 Key로 환경 변수 가져오는 것을 REDIRECT_URI로 변경
- gauthButton prepare할 때 completion 부분 파라미터로 바로 넘기도록 수정

## 🔀 변경사항
- gauthButton prepare할 때 completion 부분 파라미터로 바로 넘기도록 수정
