### PR TITLE
🔀 :: 학생 정보 페이지 자기소개 UI 변경 및 프로젝트, 수상 Response 추가

### DIFF
--- a/Projects/Domain/StudentDomain/Interface/Entity/PrizeEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/PrizeEntity.swift
@@ -1,0 +1,11 @@
+public struct PrizeEntity: Equatable {
+    public let name: String
+    public let type: String
+    public let date: String
+
+    public init(name: String, type: String, date: String) {
+        self.name = name
+        self.type = type
+        self.date = date
+    }
+}

--- a/Projects/Domain/StudentDomain/Interface/Entity/ProjectEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/ProjectEntity.swift
@@ -8,17 +8,6 @@ public struct ProjectEntity: Equatable {
     public let myActivity: String
     public let inProgress: InProgressEntity
 
-    enum CodingKeys: String, CodingKey {
-        case name
-        case iconImageURL = "icon"
-        case previewImageURLs = "previewImages"
-        case description
-        case links
-        case techStacks
-        case myActivity
-        case inProgress
-    }
-
     public init(
         name: String,
         iconImageURL: String,
@@ -44,10 +33,20 @@ public extension ProjectEntity {
     struct LinkEntity: Equatable {
         public let name: String
         public let url: String
+
+        public init(name: String, url: String) {
+            self.name = name
+            self.url = url
+        }
     }
 
     struct InProgressEntity: Equatable {
         public let start: String
         public let end: String?
+
+        public init(start: String, end: String?) {
+            self.start = start
+            self.end = end
+        }
     }
 }

--- a/Projects/Domain/StudentDomain/Interface/Entity/ProjectEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/ProjectEntity.swift
@@ -1,0 +1,53 @@
+public struct ProjectEntity: Equatable {
+    public let name: String
+    public let iconImageURL: String
+    public let previewImageURLs: [String]
+    public let description: String
+    public let links: [LinkEntity]
+    public let techStacks: [String]
+    public let myActivity: String
+    public let inProgress: InProgressEntity
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case iconImageURL = "icon"
+        case previewImageURLs = "previewImages"
+        case description
+        case links
+        case techStacks
+        case myActivity
+        case inProgress
+    }
+
+    public init(
+        name: String,
+        iconImageURL: String,
+        previewImageURLs: [String],
+        description: String,
+        links: [LinkEntity],
+        techStacks: [String],
+        myActivity: String,
+        inProgress: InProgressEntity
+    ) {
+        self.name = name
+        self.iconImageURL = iconImageURL
+        self.previewImageURLs = previewImageURLs
+        self.description = description
+        self.links = links
+        self.techStacks = techStacks
+        self.myActivity = myActivity
+        self.inProgress = inProgress
+    }
+}
+
+public extension ProjectEntity {
+    struct LinkEntity: Equatable {
+        public let name: String
+        public let url: String
+    }
+
+    struct InProgressEntity: Equatable {
+        public let start: String
+        public let end: String?
+    }
+}

--- a/Projects/Domain/StudentDomain/Interface/Entity/StudentDetailEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/StudentDetailEntity.swift
@@ -58,6 +58,8 @@ extension StudentDetailEntity {
         public let salary: Int
         public let languageCertificate: [LanguageCertificateEntity]
         public let certificate: [String]
+        public let projects: [ProjectEntity]
+        public let prizes: [PrizeEntity]
 
         public init(
             dreamBookFileURL: String?,
@@ -73,7 +75,9 @@ extension StudentDetailEntity {
             militaryService: MilitaryServiceType,
             salary: Int,
             languageCertificate: [LanguageCertificateEntity],
-            certificate: [String]
+            certificate: [String],
+            projects: [ProjectEntity],
+            prizes: [PrizeEntity]
         ) {
             self.dreamBookFileURL = dreamBookFileURL
             self.portfolioURL = portfolioURL
@@ -89,6 +93,8 @@ extension StudentDetailEntity {
             self.salary = salary
             self.languageCertificate = languageCertificate
             self.certificate = certificate
+            self.projects = projects
+            self.prizes = prizes
         }
     }
 }

--- a/Projects/Domain/StudentDomain/Interface/Entity/StudentDetailEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/StudentDetailEntity.swift
@@ -6,6 +6,8 @@ public struct StudentDetailEntity: Equatable {
     public let major: String
     public let profileImageURL: String
     public let techStacks: [String]
+    public let projects: [ProjectEntity]
+    public let prizes: [PrizeEntity]
     public let detailInfoByStudent: DetailInfoByStudent?
     public let detailInfoByTeacher: DetailInfoByTeacher?
 
@@ -15,6 +17,8 @@ public struct StudentDetailEntity: Equatable {
         major: String,
         profileImageURL: String,
         techStacks: [String],
+        projects: [ProjectEntity],
+        prizes: [PrizeEntity],
         detailInfoByStudent: DetailInfoByStudent? = nil,
         detailInfoByTeacher: DetailInfoByTeacher? = nil
     ) {
@@ -23,6 +27,8 @@ public struct StudentDetailEntity: Equatable {
         self.major = major
         self.profileImageURL = profileImageURL
         self.techStacks = techStacks
+        self.projects = projects
+        self.prizes = prizes
         self.detailInfoByStudent = detailInfoByStudent
         self.detailInfoByTeacher = detailInfoByTeacher
     }
@@ -58,8 +64,6 @@ extension StudentDetailEntity {
         public let salary: Int
         public let languageCertificate: [LanguageCertificateEntity]
         public let certificate: [String]
-        public let projects: [ProjectEntity]
-        public let prizes: [PrizeEntity]
 
         public init(
             dreamBookFileURL: String?,
@@ -75,9 +79,7 @@ extension StudentDetailEntity {
             militaryService: MilitaryServiceType,
             salary: Int,
             languageCertificate: [LanguageCertificateEntity],
-            certificate: [String],
-            projects: [ProjectEntity],
-            prizes: [PrizeEntity]
+            certificate: [String]
         ) {
             self.dreamBookFileURL = dreamBookFileURL
             self.portfolioURL = portfolioURL
@@ -93,8 +95,6 @@ extension StudentDetailEntity {
             self.salary = salary
             self.languageCertificate = languageCertificate
             self.certificate = certificate
-            self.projects = projects
-            self.prizes = prizes
         }
     }
 }

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByGuestResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByGuestResponseDTO.swift
@@ -7,13 +7,25 @@ public struct FetchStudentDetailByGuestResponseDTO: Decodable {
     public let major: String
     public let profileImg: String
     public let techStack: [String]
+    public let projects: [ProjectResponseDTO]
+    public let prizes: [PrizeResponseDTO]
 
-    public init(name: String, introduce: String, major: String, profileImg: String, techStack: [String]) {
+    public init(
+        name: String,
+        introduce: String,
+        major: String,
+        profileImg: String,
+        techStack: [String],
+        projects: [ProjectResponseDTO],
+        prizes: [PrizeResponseDTO]
+    ) {
         self.name = name
         self.introduce = introduce
         self.major = major
         self.profileImg = profileImg
         self.techStack = techStack
+        self.projects = projects
+        self.prizes = prizes
     }
 }
 
@@ -24,7 +36,9 @@ public extension FetchStudentDetailByGuestResponseDTO {
             introduce: introduce,
             major: major,
             profileImageURL: profileImg,
-            techStacks: techStack
+            techStacks: techStack,
+            projects: projects.map { $0.toDomain() },
+            prizes: prizes.map { $0.toDomain() }
         )
     }
 }

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByStudentResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByStudentResponseDTO.swift
@@ -11,6 +11,8 @@ public struct FetchStudentDetailByStudentResponseDTO: Decodable {
     public let major: String
     public let profileImg: String
     public let techStack: [String]
+    public let projects: [ProjectResponseDTO]
+    public let prizes: [PrizeResponseDTO]
 }
 
 public extension FetchStudentDetailByStudentResponseDTO {
@@ -21,6 +23,8 @@ public extension FetchStudentDetailByStudentResponseDTO {
             major: major,
             profileImageURL: profileImg,
             techStacks: techStack,
+            projects: projects.map { $0.toDomain() },
+            prizes: prizes.map { $0.toDomain() },
             detailInfoByStudent: .init(
                 grade: grade,
                 class: classNum,

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
@@ -21,6 +21,8 @@ public struct FetchStudentDetailByTeacherResponseDTO: Decodable {
     public let languageCertificates: [LanguageCertificateResponseDTO]
     public let certificates: [String]
     public let techStacks: [String]
+    public let projects: [ProjectResponseDTO]
+    public let prizes: [PrizeResponseDTO]
 
     public struct LanguageCertificateResponseDTO: Decodable {
         public let name: String
@@ -33,11 +35,82 @@ public struct FetchStudentDetailByTeacherResponseDTO: Decodable {
         }
         // swiftlint: enable nesting
     }
+
+    public struct ProjectResponseDTO: Decodable {
+        public let name: String
+        public let iconImageURL: String
+        public let previewImageURLs: [String]
+        public let description: String
+        public let links: [LinkResponseDTO]
+        public let techStacks: [String]
+        public let myActivity: String
+        public let inProgress: InProgressResponseDTO
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case iconImageURL = "icon"
+            case previewImageURLs = "previewImages"
+            case description
+            case links
+            case techStacks
+            case myActivity
+            case inProgress
+        }
+    }
+
+    public struct PrizeResponseDTO: Decodable {
+        public let name: String
+        public let type: String
+        public let date: String
+    }
+
+    public struct LinkResponseDTO: Decodable {
+        public let name: String
+        public let url: String
+    }
+
+    public struct InProgressResponseDTO: Decodable {
+        public let start: String
+        public let end: String?
+    }
 }
 
 public extension FetchStudentDetailByTeacherResponseDTO.LanguageCertificateResponseDTO {
     func toDomain() -> LanguageCertificateEntity {
         LanguageCertificateEntity(name: name, score: score)
+    }
+}
+
+public extension FetchStudentDetailByTeacherResponseDTO.ProjectResponseDTO {
+    func toDomain() -> ProjectEntity {
+        ProjectEntity(
+            name: name,
+            iconImageURL: iconImageURL,
+            previewImageURLs: previewImageURLs,
+            description: description,
+            links: links.map { $0.toDomain() },
+            techStacks: techStacks,
+            myActivity: myActivity,
+            inProgress: inProgress.toDomain()
+        )
+    }
+}
+
+public extension FetchStudentDetailByTeacherResponseDTO.LinkResponseDTO {
+    func toDomain() -> ProjectEntity.LinkEntity {
+        ProjectEntity.LinkEntity(name: name, url: url)
+    }
+}
+
+public extension FetchStudentDetailByTeacherResponseDTO.InProgressResponseDTO {
+    func toDomain() -> ProjectEntity.InProgressEntity {
+        .init(start: start, end: end)
+    }
+}
+
+public extension FetchStudentDetailByTeacherResponseDTO.PrizeResponseDTO {
+    func toDomain() -> PrizeEntity {
+        PrizeEntity(name: name, type: type, date: date)
     }
 }
 
@@ -63,7 +136,9 @@ public extension FetchStudentDetailByTeacherResponseDTO {
                 militaryService: militaryService,
                 salary: salary,
                 languageCertificate: languageCertificates.map { $0.toDomain() },
-                certificate: certificates
+                certificate: certificates,
+                projects: projects.map { $0.toDomain() },
+                prizes: prizes.map { $0.toDomain() }
             )
         )
     }

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
@@ -51,6 +51,8 @@ public extension FetchStudentDetailByTeacherResponseDTO {
             major: major,
             profileImageURL: profileImg,
             techStacks: techStacks,
+            projects: projects.map { $0.toDomain() },
+            prizes: prizes.map { $0.toDomain() },
             detailInfoByTeacher: .init(
                 dreamBookFileURL: dreamBookFileUrl,
                 portfolioURL: portfolioUrl,
@@ -65,9 +67,7 @@ public extension FetchStudentDetailByTeacherResponseDTO {
                 militaryService: militaryService,
                 salary: salary,
                 languageCertificate: languageCertificates.map { $0.toDomain() },
-                certificate: certificates,
-                projects: projects.map { $0.toDomain() },
-                prizes: prizes.map { $0.toDomain() }
+                certificate: certificates
             )
         )
     }

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/FetchStudentDetailByTeacherResponseDTO.swift
@@ -35,82 +35,11 @@ public struct FetchStudentDetailByTeacherResponseDTO: Decodable {
         }
         // swiftlint: enable nesting
     }
-
-    public struct ProjectResponseDTO: Decodable {
-        public let name: String
-        public let iconImageURL: String
-        public let previewImageURLs: [String]
-        public let description: String
-        public let links: [LinkResponseDTO]
-        public let techStacks: [String]
-        public let myActivity: String
-        public let inProgress: InProgressResponseDTO
-
-        enum CodingKeys: String, CodingKey {
-            case name
-            case iconImageURL = "icon"
-            case previewImageURLs = "previewImages"
-            case description
-            case links
-            case techStacks
-            case myActivity
-            case inProgress
-        }
-    }
-
-    public struct PrizeResponseDTO: Decodable {
-        public let name: String
-        public let type: String
-        public let date: String
-    }
-
-    public struct LinkResponseDTO: Decodable {
-        public let name: String
-        public let url: String
-    }
-
-    public struct InProgressResponseDTO: Decodable {
-        public let start: String
-        public let end: String?
-    }
 }
 
 public extension FetchStudentDetailByTeacherResponseDTO.LanguageCertificateResponseDTO {
     func toDomain() -> LanguageCertificateEntity {
         LanguageCertificateEntity(name: name, score: score)
-    }
-}
-
-public extension FetchStudentDetailByTeacherResponseDTO.ProjectResponseDTO {
-    func toDomain() -> ProjectEntity {
-        ProjectEntity(
-            name: name,
-            iconImageURL: iconImageURL,
-            previewImageURLs: previewImageURLs,
-            description: description,
-            links: links.map { $0.toDomain() },
-            techStacks: techStacks,
-            myActivity: myActivity,
-            inProgress: inProgress.toDomain()
-        )
-    }
-}
-
-public extension FetchStudentDetailByTeacherResponseDTO.LinkResponseDTO {
-    func toDomain() -> ProjectEntity.LinkEntity {
-        ProjectEntity.LinkEntity(name: name, url: url)
-    }
-}
-
-public extension FetchStudentDetailByTeacherResponseDTO.InProgressResponseDTO {
-    func toDomain() -> ProjectEntity.InProgressEntity {
-        .init(start: start, end: end)
-    }
-}
-
-public extension FetchStudentDetailByTeacherResponseDTO.PrizeResponseDTO {
-    func toDomain() -> PrizeEntity {
-        PrizeEntity(name: name, type: type, date: date)
     }
 }
 

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/PrizeResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/PrizeResponseDTO.swift
@@ -1,0 +1,14 @@
+import Foundation
+import StudentDomainInterface
+
+public struct PrizeResponseDTO: Decodable {
+    public let name: String
+    public let type: String
+    public let date: String
+}
+
+extension PrizeResponseDTO {
+    func toDomain() -> PrizeEntity {
+        PrizeEntity(name: name, type: type, date: date)
+    }
+}

--- a/Projects/Domain/StudentDomain/Sources/DTO/Response/ProjectResponseDTO.swift
+++ b/Projects/Domain/StudentDomain/Sources/DTO/Response/ProjectResponseDTO.swift
@@ -1,0 +1,63 @@
+import Foundation
+import StudentDomainInterface
+
+public struct ProjectResponseDTO: Decodable {
+    public let name: String
+    public let iconImageURL: String
+    public let previewImageURLs: [String]
+    public let description: String
+    public let links: [LinkResponseDTO]
+    public let techStacks: [String]
+    public let myActivity: String
+    public let inProgress: InProgressResponseDTO
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case iconImageURL = "icon"
+        case previewImageURLs = "previewImages"
+        case description
+        case links
+        case techStacks
+        case myActivity
+        case inProgress
+    }
+}
+
+extension ProjectResponseDTO {
+    public struct LinkResponseDTO: Decodable {
+        public let name: String
+        public let url: String
+    }
+
+    public struct InProgressResponseDTO: Decodable {
+        public let start: String
+        public let end: String?
+    }
+}
+
+extension ProjectResponseDTO {
+    func toDomain() -> ProjectEntity {
+        ProjectEntity(
+            name: name,
+            iconImageURL: iconImageURL,
+            previewImageURLs: previewImageURLs,
+            description: description,
+            links: links.map { $0.toDomain() },
+            techStacks: techStacks,
+            myActivity: myActivity,
+            inProgress: inProgress.toDomain()
+        )
+    }
+}
+
+extension ProjectResponseDTO.LinkResponseDTO {
+    func toDomain() -> ProjectEntity.LinkEntity {
+        ProjectEntity.LinkEntity(name: name, url: url)
+    }
+}
+
+extension ProjectResponseDTO.InProgressResponseDTO {
+    func toDomain() -> ProjectEntity.InProgressEntity {
+        .init(start: start, end: end)
+    }
+}

--- a/Projects/Domain/StudentDomain/Testing/UseCase/FetchStudentUseCaseSpy.swift
+++ b/Projects/Domain/StudentDomain/Testing/UseCase/FetchStudentUseCaseSpy.swift
@@ -15,7 +15,9 @@ public final class FetchStudentDetailUseCaseSpy: FetchStudentDetailUseCase {
             introduce: "introduce",
             major: "major",
             profileImageURL: "https://avatars.githubusercontent.com/u/74440939?v=4",
-            techStacks: []
+            techStacks: [],
+            projects: [],
+            prizes: []
         )
     }
 }

--- a/Projects/Feature/StudentDetailFeature/Sources/Model/StudentDetailModel.swift
+++ b/Projects/Feature/StudentDetailFeature/Sources/Model/StudentDetailModel.swift
@@ -14,6 +14,8 @@ final class StudentDetailModel: ObservableObject, StudentDetailStateProtocol {
                     major: $0.major,
                     profileImageURL: $0.profileImageURL,
                     techStacks: $0.techStacks,
+                    projects: $0.projects,
+                    prizes: $0.prizes,
                     detailInfoByStudent: $0.detailInfoByStudent,
                     detailInfoByTeacher: $0.detailInfoByTeacher
                 )
@@ -28,7 +30,7 @@ final class StudentDetailModel: ObservableObject, StudentDetailStateProtocol {
     @Published var hwpDocument: HWPDocument?
     var hwpFilename: String {
         guard let studentDetailEntity, let info = studentDetailEntity.detailInfoByTeacher else { return "" }
-        var number = info.number >= 10 ? "\(info.number)" : "0\(info.number)"
+        let number = info.number >= 10 ? "\(info.number)" : "0\(info.number)"
         return "\(info.grade)\(info.class)\(number)\(studentDetailEntity.name)-드림북.hwp"
     }
 }

--- a/Projects/Feature/StudentDetailFeature/Sources/Scene/StudentDetailView.swift
+++ b/Projects/Feature/StudentDetailFeature/Sources/Scene/StudentDetailView.swift
@@ -194,9 +194,20 @@ struct StudentDetailView: View {
             Group {
                 Spacer().frame(height: 16)
 
-                SMSText(studentDetail?.introduce ?? "자기소개", font: .body2)
-                    .foregroundColor(.sms(.neutral(.n40)))
-                    .lineLimit(nil)
+                ZStack(alignment: .topLeading) {
+                    Color.sms(.neutral(.n10))
+                        .cornerRadius(8)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        SMSText("자기소개", font: .caption2)
+                            .foregroundColor(.sms(.neutral(.n40)))
+
+                        SMSText(studentDetail?.introduce ?? "자기소개", font: .body2)
+                            .foregroundColor(.sms(.system(.black)))
+                            .lineLimit(nil)
+                    }
+                    .padding(16)
+                }
 
                 Spacer().frame(height: 32)
 


### PR DESCRIPTION
## 💡 개요
<img src="https://github.com/GSM-MSG/SMS-iOS/assets/74440939/4e5ee309-cbb4-4070-9b98-c66e2de05a7e" width="150" />

## 📃 작업내용
- 학생의 자기소개 정보를 띄우는 UI 변경

## 🔀 변경사항
- 학생의 자기소개 정보를 띄우는 UI 변경
