### PR TITLE
🔀 :: 학생 정보 디테일 페이지에 수상 항목 추가

### DIFF
--- a/Projects/Domain/StudentDomain/Interface/Entity/PrizeEntity.swift
+++ b/Projects/Domain/StudentDomain/Interface/Entity/PrizeEntity.swift
@@ -1,4 +1,4 @@
-public struct PrizeEntity: Equatable {
+public struct PrizeEntity: Equatable, Hashable {
     public let name: String
     public let type: String
     public let date: String

--- a/Projects/Feature/StudentDetailFeature/Sources/Scene/StudentDetailView.swift
+++ b/Projects/Feature/StudentDetailFeature/Sources/Scene/StudentDetailView.swift
@@ -214,6 +214,13 @@ struct StudentDetailView: View {
                 UnwrapView(studentDetail?.detailInfoByTeacher) { detailInfoByTeacher in
                     studentInfoForTeacher(geometry: geometry, detailInfo: detailInfoByTeacher)
                 }
+
+                VStack(spacing: 8) {
+                    ForEach(studentDetail?.prizes ?? [], id: \.self) { prize in
+                        PrizeRowView(prize: prize)
+                    }
+                }
+                .studentDetailTitleWrapper(title: "수상")
             }
 
             Color.sms(.system(.white))
@@ -295,6 +302,7 @@ struct StudentDetailView: View {
 
             Spacer().frame(height: 120)
         }
+        .studentDetailTitleWrapper(title: "수상")
     }
 
     @ViewBuilder

--- a/Projects/Feature/StudentDetailFeature/Sources/Scene/View/PrizeRowView.swift
+++ b/Projects/Feature/StudentDetailFeature/Sources/Scene/View/PrizeRowView.swift
@@ -1,0 +1,34 @@
+import DesignSystem
+import SwiftUI
+import StudentDomainInterface
+
+struct PrizeRowView: View {
+    let prize: PrizeEntity
+
+    init(prize: PrizeEntity) {
+        self.prize = prize
+    }
+
+    var body: some View {
+        ZStack {
+            Color.sms(.neutral(.n10))
+                .cornerRadius(8)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    SMSText(prize.name)
+                        .foregroundColor(.sms(.system(.black)))
+
+                    Spacer()
+
+                    SMSText(prize.date, font: .caption2)
+                        .foregroundColor(.sms(.system(.black)))
+                }
+
+                SMSText(prize.type, font: .caption2)
+                    .foregroundColor(.sms(.neutral(.n40)))
+            }
+            .padding(8)
+        }
+    }
+}

--- a/Projects/Feature/StudentDetailFeature/Sources/Scene/View/StudentDetailTitleWrapper.swift
+++ b/Projects/Feature/StudentDetailFeature/Sources/Scene/View/StudentDetailTitleWrapper.swift
@@ -1,0 +1,25 @@
+import DesignSystem
+import SwiftUI
+
+struct StudentDetailTitleWrapper: ViewModifier {
+    let title: String
+
+    init(title: String) {
+        self.title = title
+    }
+
+    func body(content: Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .smsFont(.title2, color: .system(.black))
+
+            content
+        }
+    }
+}
+
+extension View {
+    func studentDetailTitleWrapper(title: String) -> some View {
+        self.modifier(StudentDetailTitleWrapper(title: title))
+    }
+}


### PR DESCRIPTION
## 💡 개요
<img src="https://github.com/GSM-MSG/SMS-iOS/assets/74440939/271b48bc-9cc1-4d71-ba9c-76ea24b957ef" width="150" />

## 📃 작업내용
- StudentDetailView에 수상 UI 추가
