### PR TITLE
🔀 :: [#219] 수상 정보 입력 추가

### DIFF
--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
@@ -254,6 +254,10 @@ public extension TargetDependency.Core {
 }
 
 public extension TargetDependency.Shared {
+    static let ConcurrencyUtil = TargetDependency.project(
+        target: ModulePaths.Shared.ConcurrencyUtil.targetName(type: .sources),
+        path: .relativeToShared(ModulePaths.Shared.ConcurrencyUtil.rawValue)
+    )
     static let Validator = TargetDependency.project(
         target: ModulePaths.Shared.Validator.targetName(type: .sources),
         path: .relativeToShared(ModulePaths.Shared.Validator.rawValue)

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
@@ -9,6 +9,14 @@ public extension TargetDependency {
 }
 
 public extension TargetDependency.Feature {
+    static let InputPrizeInfoFeatureInterface = TargetDependency.project(
+        target: ModulePaths.Feature.InputPrizeInfoFeature.targetName(type: .interface),
+        path: .relativeToFeature(ModulePaths.Feature.InputPrizeInfoFeature.rawValue)
+    )
+    static let InputPrizeInfoFeature = TargetDependency.project(
+        target: ModulePaths.Feature.InputPrizeInfoFeature.targetName(type: .sources),
+        path: .relativeToFeature(ModulePaths.Feature.InputPrizeInfoFeature.rawValue)
+    )
     static let InputProjectInfoFeatureInterface = TargetDependency.project(
         target: ModulePaths.Feature.InputProjectInfoFeature.targetName(type: .interface),
         path: .relativeToFeature(ModulePaths.Feature.InputProjectInfoFeature.rawValue)

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
@@ -10,6 +10,7 @@ public enum ModulePaths {
 
 public extension ModulePaths {
     enum Feature: String {
+        case InputPrizeInfoFeature
         case InputProjectInfoFeature
         case SplashFeature
         case MainFeature

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
@@ -65,6 +65,7 @@ public extension ModulePaths {
 
 public extension ModulePaths {
     enum Shared: String {
+        case ConcurrencyUtil
         case Validator
         case FoundationUtil
         case ViewUtil

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -41,6 +41,7 @@ let targets: [Target] = [
             .Feature.SigninFeature,
             .Feature.InputInformationFeature,
             .Feature.InputProfileInfoFeature,
+            .Feature.InputPrizeInfoFeature,
             .Feature.InputSchoolLifeInfoFeature,
             .Feature.InputWorkInfoFeature,
             .Feature.InputMilitaryInfoFeature,

--- a/Projects/App/Sources/Application/DI/AppComponent.swift
+++ b/Projects/App/Sources/Application/DI/AppComponent.swift
@@ -91,7 +91,7 @@ final class AppComponent: BootstrapComponent {
     }
 
     var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
-        inputPrizeInfoBuildable(parent: self)
+        InputPrizeInfoComponent(parent: self)
     }
 
     var inputProjectInfoBuildable: any InputProjectInfoBuildable {

--- a/Projects/App/Sources/Application/DI/AppComponent.swift
+++ b/Projects/App/Sources/Application/DI/AppComponent.swift
@@ -13,6 +13,8 @@ import InputLanguageInfoFeature
 import InputLanguageInfoFeatureInterface
 import InputMilitaryInfoFeature
 import InputMilitaryInfoFeatureInterface
+import InputPrizeInfoFeature
+import InputPrizeInfoFeatureInterface
 import InputProfileInfoFeature
 import InputProfileInfoFeatureInterface
 import InputProjectInfoFeature
@@ -86,6 +88,10 @@ final class AppComponent: BootstrapComponent {
 
     var inputLanguageInfoBuildable: any InputLanguageInfoBuildable {
         InputLanguageInfoComponent(parent: self)
+    }
+
+    var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
+        inputPrizeInfoBuildable(parent: self)
     }
 
     var inputProjectInfoBuildable: any InputProjectInfoBuildable {

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -96,6 +96,9 @@ private class InputProjectInfoDependencye065c7f60c5c520999a0Provider: InputProje
     var techStackAppendBuildable: any TechStackAppendBuildable {
         return appComponent.techStackAppendBuildable
     }
+    var fileDomainBuildable: any FileDomainBuildable {
+        return appComponent.fileDomainBuildable
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -265,6 +268,9 @@ private class InputInformationDependency7b32a8e7e8a8f0ab5466Provider: InputInfor
     }
     var inputProjectInfoBuildable: any InputProjectInfoBuildable {
         return appComponent.inputProjectInfoBuildable
+    }
+    var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
+        return appComponent.inputPrizeInfoBuildable
     }
     var fileDomainBuildable: any FileDomainBuildable {
         return appComponent.fileDomainBuildable
@@ -439,6 +445,7 @@ extension SplashComponent: Registration {
 extension InputProjectInfoComponent: Registration {
     public func registerItems() {
         keyPathToName[\InputProjectInfoDependency.techStackAppendBuildable] = "techStackAppendBuildable-any TechStackAppendBuildable"
+        keyPathToName[\InputProjectInfoDependency.fileDomainBuildable] = "fileDomainBuildable-any FileDomainBuildable"
     }
 }
 extension InputWorkInfoComponent: Registration {
@@ -505,6 +512,7 @@ extension InputInformationComponent: Registration {
         keyPathToName[\InputInformationDependency.inputCertificateInfoBuildable] = "inputCertificateInfoBuildable-any InputCertificateInfoBuildable"
         keyPathToName[\InputInformationDependency.inputLanguageInfoBuildable] = "inputLanguageInfoBuildable-any InputLanguageInfoBuildable"
         keyPathToName[\InputInformationDependency.inputProjectInfoBuildable] = "inputProjectInfoBuildable-any InputProjectInfoBuildable"
+        keyPathToName[\InputInformationDependency.inputPrizeInfoBuildable] = "inputPrizeInfoBuildable-any InputPrizeInfoBuildable"
         keyPathToName[\InputInformationDependency.fileDomainBuildable] = "fileDomainBuildable-any FileDomainBuildable"
         keyPathToName[\InputInformationDependency.studentDomainBuildable] = "studentDomainBuildable-any StudentDomainBuildable"
     }

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -17,6 +17,8 @@ import InputLanguageInfoFeature
 import InputLanguageInfoFeatureInterface
 import InputMilitaryInfoFeature
 import InputMilitaryInfoFeatureInterface
+import InputPrizeInfoFeature
+import InputPrizeInfoFeatureInterface
 import InputProfileInfoFeature
 import InputProfileInfoFeatureInterface
 import InputProjectInfoFeature
@@ -322,6 +324,17 @@ private class InputProfileInfoDependencydedc6189ad35e7ff3001Provider: InputProfi
 private func factoryb3d74d9bff60efbc0282f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return InputProfileInfoDependencydedc6189ad35e7ff3001Provider(appComponent: parent1(component) as! AppComponent)
 }
+private class InputPrizeInfoDependencyff32e2191f3500ff4774Provider: InputPrizeInfoDependency {
+
+
+    init() {
+
+    }
+}
+/// ^->AppComponent->InputPrizeInfoComponent
+private func factory4b0dfd60fcb5e700b51ce3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return InputPrizeInfoDependencyff32e2191f3500ff4774Provider()
+}
 private class FileDomainDependency2b4ac3753c2aa3928546Provider: FileDomainDependency {
     var jwtStoreBuildable: any JwtStoreBuildable {
         return appComponent.jwtStoreBuildable
@@ -513,6 +526,11 @@ extension InputProfileInfoComponent: Registration {
         keyPathToName[\InputProfileInfoDependency.techStackAppendBuildable] = "techStackAppendBuildable-any TechStackAppendBuildable"
     }
 }
+extension InputPrizeInfoComponent: Registration {
+    public func registerItems() {
+
+    }
+}
 extension FileDomainComponent: Registration {
     public func registerItems() {
         keyPathToName[\FileDomainDependency.jwtStoreBuildable] = "jwtStoreBuildable-any JwtStoreBuildable"
@@ -558,7 +576,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
 
 #if !NEEDLE_DYNAMIC
 
-@inline(never) private func register1() {
+private func register1() {
     registerProviderFactory("^->AppComponent->JwtStoreComponent", factoryb27d5aae1eb7e73575a6f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent", factoryEmptyDependencyProvider)
     registerProviderFactory("^->AppComponent->KeychainComponent", factoryEmptyDependencyProvider)
@@ -577,6 +595,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->InputCertificateInfoComponent", factory9df85876e39e1206b924e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->StudentDetailComponent", factory3e27a26da31e522f5755f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InputProfileInfoComponent", factoryb3d74d9bff60efbc0282f47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->InputPrizeInfoComponent", factory4b0dfd60fcb5e700b51ce3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->FileDomainComponent", factoryd99c631e7a9c4984df37f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->StudentDomainComponent", factory2686a7e321a220c3265af47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->TechStackDomainComponent", factory254149359ff45b2db35bf47b58f8f304c97af4d5)

--- a/Projects/Domain/FileDomain/Testing/UseCase/ImageUploadUseCaseSpy.swift
+++ b/Projects/Domain/FileDomain/Testing/UseCase/ImageUploadUseCaseSpy.swift
@@ -1,9 +1,10 @@
-//
-//  ImageUploadUseCaseSpy.swift
-//  FileDomainInterface
-//
-//  Created by sunghun on 8/2/23.
-//  Copyright © 2023 com.msg. All rights reserved.
-//
-
+import FileDomainInterface
 import Foundation
+
+final class ImageUploadUseCaseSpy: ImageUploadUseCase {
+    var executeCallCount = 0
+    func execute(image: Data, fileName: String) async throws -> String {
+        executeCallCount += 1
+        return "A"
+    }
+}

--- a/Projects/Domain/FileDomain/Testing/UseCase/ImageUploadUseCaseSpy.swift
+++ b/Projects/Domain/FileDomain/Testing/UseCase/ImageUploadUseCaseSpy.swift
@@ -1,0 +1,9 @@
+//
+//  ImageUploadUseCaseSpy.swift
+//  FileDomainInterface
+//
+//  Created by sunghun on 8/2/23.
+//  Copyright © 2023 com.msg. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Domain/StudentDomain/Interface/DTO/Request/StudentRequestDTO.swift
+++ b/Projects/Domain/StudentDomain/Interface/DTO/Request/StudentRequestDTO.swift
@@ -95,6 +95,26 @@ public extension InputStudentInformationRequestDTO {
         public let myActivity: String
         public let inProgress: InProgress
 
+        public init(
+            name: String,
+            iconImageURL: String,
+            previewImageURLs: [String],
+            description: String,
+            links: [Link],
+            techStacks: [String],
+            myActivity: String,
+            inProgress: InProgress
+        ) {
+            self.name = name
+            self.iconImageURL = iconImageURL
+            self.previewImageURLs = previewImageURLs
+            self.description = description
+            self.links = links
+            self.techStacks = techStacks
+            self.myActivity = myActivity
+            self.inProgress = inProgress
+        }
+
         enum CodingKeys: String, CodingKey {
             case name
             case iconImageURL = "icon"
@@ -111,6 +131,16 @@ public extension InputStudentInformationRequestDTO {
         public let name: String
         public let type: String
         public let date: String
+
+        public init(
+            name: String,
+            type: String,
+            date: String
+        ) {
+            self.name = name
+            self.type = type
+            self.date = date
+        }
     }
 }
 
@@ -118,10 +148,20 @@ public extension InputStudentInformationRequestDTO.Project {
     struct Link: Encodable {
         public let name: String
         public let url: String
+
+        public init(name: String, url: String) {
+            self.name = name
+            self.url = url
+        }
     }
 
     struct InProgress: Encodable {
         public let start: String
         public let end: String?
+
+        public init(start: String, end: String?) {
+            self.start = start
+            self.end = end
+        }
     }
 }

--- a/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
+++ b/Projects/Feature/InputCertificateInfoFeature/Sources/Scene/InputCertificateInfoView.swift
@@ -20,7 +20,7 @@ struct InputCertificateInfoView: View {
                         InputInformationPageTitleView(
                             title: "자격증",
                             isRequired: false,
-                            pageCount: 7,
+                            pageCount: 8,
                             selectedPage: 4
                         )
 

--- a/Projects/Feature/InputInformationFeature/Project.swift
+++ b/Projects/Feature/InputInformationFeature/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeModule(
         .Feature.InputCertificateInfoFeatureInterface,
         .Feature.InputLanguageInfoFeatureInterface,
         .Feature.InputProjectInfoFeatureInterface,
+        .Feature.InputPrizeInfoFeatureInterface,
         .Domain.FileDomainInterface,
         .Domain.StudentDomainInterface,
         .Domain.UserDomainInterface

--- a/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/DI/InputInformationComponent.swift
@@ -8,6 +8,7 @@ import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 import NeedleFoundation
 import StudentDomainInterface
 import SwiftUI
@@ -20,6 +21,7 @@ public protocol InputInformationDependency: Dependency {
     var inputCertificateInfoBuildable: any InputCertificateInfoBuildable { get }
     var inputLanguageInfoBuildable: any InputLanguageInfoBuildable { get }
     var inputProjectInfoBuildable: any InputProjectInfoBuildable { get }
+    var inputPrizeInfoBuildable: any InputPrizeInfoBuildable { get }
     var fileDomainBuildable: any FileDomainBuildable { get }
     var studentDomainBuildable: any StudentDomainBuildable { get }
 }
@@ -50,6 +52,7 @@ public final class InputInformationComponent:
             inputCertificateInfoBuildable: dependency.inputCertificateInfoBuildable,
             inputLanguageInfoBuildable: dependency.inputLanguageInfoBuildable,
             inputProjectInfoBuildable: dependency.inputProjectInfoBuildable,
+            inputPrizeInfoBuildable: dependency.inputPrizeInfoBuildable,
             container: container
         )
     }

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -8,6 +8,7 @@ import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 import StudentDomainInterface
 
 final class InputInformationIntent: InputInformationIntentProtocol {
@@ -160,5 +161,11 @@ extension InputInformationIntent: InputProjectInfoDelegate {
     func completeToInputProjectInfo(input: [InputProjectInfoObject]) {
         model?.updateProjects(projects: input)
         model?.updateIsCompleteToInputAllInfo(isComplete: true)
+    }
+}
+
+extension InputInformationIntent: InputPrizeDelegate {
+    func prizeInfoPrevButtonDidTap() {
+        model?.prevButtonDidTap()
     }
 }

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -46,11 +46,11 @@ final class InputInformationIntent: InputInformationIntentProtocol {
         model?.updateIsLoading(isLoading: true)
         Task {
             do {
-                async let profileImageURL = self.imageUploadUseCase.execute(
+                async let profileImageURL = imageUploadUseCase.execute(
                     image: inputProfileInfo.profileImageData,
                     fileName: inputProfileInfo.profileImageFilename
                 )
-                async let dreamBookURL = self.dreamBookUploadUseCase.execute(
+                async let dreamBookURL = dreamBookUploadUseCase.execute(
                     file: inputSchoolLifeInfo.hwpData,
                     fileName: inputSchoolLifeInfo.hwpFilename
                 )

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -46,11 +46,11 @@ final class InputInformationIntent: InputInformationIntentProtocol {
         model?.updateIsLoading(isLoading: true)
         Task {
             do {
-                async let profileImageURL = imageUploadUseCase.execute(
+                async let profileImageURL = self.imageUploadUseCase.execute(
                     image: inputProfileInfo.profileImageData,
                     fileName: inputProfileInfo.profileImageFilename
                 )
-                async let dreamBookURL = dreamBookUploadUseCase.execute(
+                async let dreamBookURL = self.dreamBookUploadUseCase.execute(
                     file: inputSchoolLifeInfo.hwpData,
                     fileName: inputSchoolLifeInfo.hwpFilename
                 )
@@ -69,9 +69,10 @@ final class InputInformationIntent: InputInformationIntentProtocol {
                     profileImgURL: profileImageURL,
                     region: inputWorkInfo.workRegion,
                     salary: inputWorkInfo.salary,
-                    techStack: inputProfileInfo.techStack
+                    techStack: inputProfileInfo.techStack,
+                    projects: state.projects.map { $0.toDTO() },
+                    prizes: state.prizes.map { $0.toDTO() }
                 )
-                #warning("프로젝트, 수상 정보 Request DTO에 담는 로직 추가")
 
                 try await inputInformationUseCase.execute(req: inputInformationRequest)
                 inputInformationDelegate?.completeToInputInformation()
@@ -161,12 +162,18 @@ extension InputInformationIntent: InputProjectInfoDelegate {
 
     func completeToInputProjectInfo(input: [InputProjectInfoObject]) {
         model?.updateProjects(projects: input)
-        model?.updateIsCompleteToInputAllInfo(isComplete: true)
+        model?.nextButtonDidTap()
     }
 }
 
 extension InputInformationIntent: InputPrizeDelegate {
     func prizeInfoPrevButtonDidTap() {
         model?.prevButtonDidTap()
+    }
+
+    func completeToInputPrizeInfo(input: [InputPrizeInfoObject]) {
+        model?.updatePrizes(prizes: input)
+        model?.nextButtonDidTap()
+        model?.updateIsCompleteToInputAllInfo(isComplete: true)
     }
 }

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntent.swift
@@ -173,7 +173,6 @@ extension InputInformationIntent: InputPrizeDelegate {
 
     func completeToInputPrizeInfo(input: [InputPrizeInfoObject]) {
         model?.updatePrizes(prizes: input)
-        model?.nextButtonDidTap()
         model?.updateIsCompleteToInputAllInfo(isComplete: true)
     }
 }

--- a/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntentProtocol.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Intent/InputInformationIntentProtocol.swift
@@ -6,6 +6,7 @@ import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 
 protocol InputInformationIntentProtocol:
     InputProfileDelegate,
@@ -14,7 +15,8 @@ protocol InputInformationIntentProtocol:
     InputMilitaryDelegate,
     InputCertificateDelegate,
     InputLanguageDelegate,
-    InputProjectInfoDelegate {
+    InputProjectInfoDelegate,
+    InputPrizeDelegate {
     func completeToInputAllInfo(state: any InputInformationStateProtocol)
     func errorAlertDismissed()
 }

--- a/Projects/Feature/InputInformationFeature/Sources/Model/InputInformationModel.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Model/InputInformationModel.swift
@@ -3,6 +3,7 @@ import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 import StudentDomainInterface
 
 final class InputInformationModel: ObservableObject, InputInformationStateProtocol {
@@ -17,6 +18,7 @@ final class InputInformationModel: ObservableObject, InputInformationStateProtoc
     var militaryServiceType: MilitaryServiceType?
     var languages: [InputStudentInformationRequestDTO.LanguageCertificate] = []
     var projects: [InputProjectInfoObject] = []
+    var prizes: [InputPrizeInfoObject] = []
     @Published var isCompleteToInputAllInfo: Bool = false
 }
 
@@ -61,6 +63,10 @@ extension InputInformationModel: InputInformationActionProtocol {
 
     func updateProjects(projects: [InputProjectInfoObject]) {
         self.projects = projects
+    }
+
+    func updatePrizes(prizes: [InputPrizeInfoObject]) {
+        self.prizes = prizes
     }
 
     func updateIsCompleteToInputAllInfo(isComplete: Bool) {

--- a/Projects/Feature/InputInformationFeature/Sources/Model/InputInformationModelProtocol.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Model/InputInformationModelProtocol.swift
@@ -3,6 +3,7 @@ import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
 import InputWorkInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 import StudentDomainInterface
 
 enum InformationPhase: CaseIterable {
@@ -13,6 +14,7 @@ enum InformationPhase: CaseIterable {
     case certificate
     case language
     case project
+    case prize
 }
 
 protocol InputInformationStateProtocol {
@@ -27,6 +29,7 @@ protocol InputInformationStateProtocol {
     var militaryServiceType: MilitaryServiceType? { get }
     var languages: [InputStudentInformationRequestDTO.LanguageCertificate] { get }
     var projects: [InputProjectInfoObject] { get }
+    var prizes: [InputPrizeInfoObject] { get }
     var isCompleteToInputAllInfo: Bool { get }
 }
 
@@ -40,6 +43,7 @@ protocol InputInformationActionProtocol: AnyObject {
     func updateMilitaryServiceType(type: MilitaryServiceType)
     func updateLanguages(languages: [InputStudentInformationRequestDTO.LanguageCertificate])
     func updateProjects(projects: [InputProjectInfoObject])
+    func updatePrizes(prizes: [InputPrizeInfoObject])
     func updateIsCompleteToInputAllInfo(isComplete: Bool)
     func updateIsLoading(isLoading: Bool)
     func updateIsError(isError: Bool)

--- a/Projects/Feature/InputInformationFeature/Sources/Scene/InputInformationView.swift
+++ b/Projects/Feature/InputInformationFeature/Sources/Scene/InputInformationView.swift
@@ -3,6 +3,7 @@ import DesignSystem
 import InputCertificateInfoFeatureInterface
 import InputLanguageInfoFeatureInterface
 import InputMilitaryInfoFeatureInterface
+import InputPrizeInfoFeatureInterface
 import InputProfileInfoFeatureInterface
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeatureInterface
@@ -22,6 +23,7 @@ struct InputInformationView: View {
     private let inputCertificateInfoBuildable: any InputCertificateInfoBuildable
     private let inputLanguageInfoBuildable: any InputLanguageInfoBuildable
     private let inputProjectInfoBuildable: any InputProjectInfoBuildable
+    private let inputPrizeInfoBuildable: any InputPrizeInfoBuildable
 
     init(
         inputProfileInfoBuildable: any InputProfileInfoBuildable,
@@ -31,6 +33,7 @@ struct InputInformationView: View {
         inputCertificateInfoBuildable: any InputCertificateInfoBuildable,
         inputLanguageInfoBuildable: any InputLanguageInfoBuildable,
         inputProjectInfoBuildable: any InputProjectInfoBuildable,
+        inputPrizeInfoBuildable: any InputPrizeInfoBuildable,
         container: MVIContainer<InputInformationIntentProtocol, InputInformationStateProtocol>
     ) {
         self.inputProfileInfoBuildable = inputProfileInfoBuildable
@@ -40,6 +43,7 @@ struct InputInformationView: View {
         self.inputCertificateInfoBuildable = inputCertificateInfoBuildable
         self.inputLanguageInfoBuildable = inputLanguageInfoBuildable
         self.inputProjectInfoBuildable = inputProjectInfoBuildable
+        self.inputPrizeInfoBuildable = inputPrizeInfoBuildable
         self._container = StateObject(wrappedValue: container)
     }
 
@@ -77,6 +81,10 @@ struct InputInformationView: View {
             inputProjectInfoBuildable.makeView(delegate: intent)
                 .eraseToAnyView()
                 .tag(InformationPhase.project)
+
+            inputPrizeInfoBuildable.makeView(delegate: intent)
+                .eraseToAnyView()
+                .tag(InformationPhase.prize)
         }
         .ignoresSafeArea(.container, edges: .top)
         .smsAlert(

--- a/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
+++ b/Projects/Feature/InputLanguageInfoFeature/Sources/Scene/InputLanguageInfoView.swift
@@ -20,7 +20,7 @@ struct InputLanguageInfoView: View {
                         InputInformationPageTitleView(
                             title: "외국어",
                             isRequired: false,
-                            pageCount: 7,
+                            pageCount: 8,
                             selectedPage: 5
                         )
 

--- a/Projects/Feature/InputMilitaryInfoFeature/Sources/Scene/InputMilitaryInfoView.swift
+++ b/Projects/Feature/InputMilitaryInfoFeature/Sources/Scene/InputMilitaryInfoView.swift
@@ -15,7 +15,7 @@ struct InputMilitaryInfoView: View {
                 SMSSeparator()
 
                 VStack(spacing: 32) {
-                    InputInformationPageTitleView(title: "병역", pageCount: 7, selectedPage: 3)
+                    InputInformationPageTitleView(title: "병역", pageCount: 8, selectedPage: 3)
 
                     VStack(spacing: 24) {
                         SMSTextField(

--- a/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
@@ -1,0 +1,2 @@
+public protocol InputPrizeDelegate: AnyObject {
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
@@ -1,3 +1,37 @@
+import Foundation
+import StudentDomainInterface
+import DateUtil
+
 public protocol InputPrizeDelegate: AnyObject {
     func prizeInfoPrevButtonDidTap()
+    func completeToInputPrizeInfo(input: [InputPrizeInfoObject])
+}
+
+public struct InputPrizeInfoObject {
+    public let name: String
+    public let prize: String
+    public let prizeAt: Date
+
+    public init(
+        name: String,
+        prize: String,
+        prizeAt: Date
+    ) {
+        self.name = name
+        self.prize = prize
+        self.prizeAt = prizeAt
+    }
+}
+
+public extension InputPrizeInfoObject {
+    var prizeAtString: String {
+        prizeAt.toStringCustomFormat(format: "yyyy.MM")
+    }
+    func toDTO() -> InputStudentInformationRequestDTO.Prize {
+        InputStudentInformationRequestDTO.Prize(
+            name: name,
+            type: prize,
+            date: prizeAtString
+        )
+    }
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeDelegate.swift
@@ -1,2 +1,3 @@
 public protocol InputPrizeDelegate: AnyObject {
+    func prizeInfoPrevButtonDidTap()
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeInfoBuildable.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Interface/InputPrizeInfoBuildable.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+public protocol InputPrizeInfoBuildable {
+    associatedtype ViewType: View
+    func makeView(delegate: InputPrizeDelegate) -> ViewType
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Project.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Project.swift
@@ -7,6 +7,7 @@ let project = Project.makeModule(
     product: .staticLibrary,
     targets: [.interface, .unitTest],
     internalDependencies: [
-        .Feature.BaseFeature
+        .Feature.BaseFeature,
+        .Feature.InputInformationBaseFeature
     ]
 )

--- a/Projects/Feature/InputPrizeInfoFeature/Project.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project.makeModule(
     targets: [.interface, .unitTest],
     internalDependencies: [
         .Feature.BaseFeature,
-        .Feature.InputInformationBaseFeature
+        .Feature.InputInformationBaseFeature,
+        .Domain.FileDomainInterface
     ]
 )

--- a/Projects/Feature/InputPrizeInfoFeature/Project.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Project.swift
@@ -8,7 +8,6 @@ let project = Project.makeModule(
     targets: [.interface, .unitTest],
     internalDependencies: [
         .Feature.BaseFeature,
-        .Feature.InputInformationBaseFeature,
-        .Domain.FileDomainInterface
+        .Feature.InputInformationBaseFeature
     ]
 )

--- a/Projects/Feature/InputPrizeInfoFeature/Project.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePaths.Feature.InputPrizeInfoFeature.rawValue,
+    product: .staticLibrary,
+    targets: [.interface, .unitTest],
+    internalDependencies: [
+        .Feature.BaseFeature
+    ]
+)

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/DI/InputPrizeInfoComponent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/DI/InputPrizeInfoComponent.swift
@@ -1,0 +1,22 @@
+import BaseFeature
+import InputPrizeInfoFeatureInterface
+import NeedleFoundation
+import SwiftUI
+
+public protocol InputPrizeInfoDependency: Dependency {}
+
+public final class InputPrizeInfoComponent:
+    Component<InputPrizeInfoDependency>,
+    InputPrizeInfoBuildable {
+
+    public func makeView(delegate: InputPrizeDelegate) -> some View {
+        let model = InputPrizeInfoModel()
+        let intent = InputPrizeInfoIntent(model: model, prizeDelegate: delegate)
+        let container = MVIContainer(
+            intent: intent as InputPrizeInfoIntentProtocol,
+            model: model as InputPrizeInfoStateProtocol,
+            modelChangePublisher: model.objectWillChange
+        )
+        return InputPrizeInfoView(container: container)
+    }
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/DI/InputPrizeInfoComponent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/DI/InputPrizeInfoComponent.swift
@@ -11,7 +11,7 @@ public final class InputPrizeInfoComponent:
 
     public func makeView(delegate: InputPrizeDelegate) -> some View {
         let model = InputPrizeInfoModel()
-        let intent = InputPrizeInfoIntent(model: model, prizeDelegate: delegate)
+        let intent = InputPrizeInfoIntent(model: model, delegate: delegate)
         let container = MVIContainer(
             intent: intent as InputPrizeInfoIntentProtocol,
             model: model as InputPrizeInfoStateProtocol,

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
@@ -29,7 +29,7 @@ final class InputPrizeInfoIntent: InputPrizeInfoIntentProtocol {
     }
 
     func prizeToggleButtonDidTap(index: Int) {
-        model?.toggleCollapsedProject(index: index)
+        model?.toggleCollapsedPrize(index: index)
     }
 
     func updatePrizeName(index: Int, name: String) {

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
@@ -3,13 +3,73 @@ import InputPrizeInfoFeatureInterface
 
 final class InputPrizeInfoIntent: InputPrizeInfoIntentProtocol {
     private weak var model: (any InputPrizeInfoActionProtocol)?
-    private weak var prizeDelegate: (any InputPrizeDelegate)?
+    private weak var delegate: (any InputPrizeDelegate)?
 
     init(
         model: any InputPrizeInfoActionProtocol,
-        prizeDelegate: any InputPrizeDelegate
+        delegate: any InputPrizeDelegate
     ) {
         self.model = model
-        self.prizeDelegate = prizeDelegate
+        self.delegate = delegate
+    }
+
+    func prevButtonDidTap() {
+        delegate?.prizeInfoPrevButtonDidTap()
+    }
+
+    func nextButtonDidTap(prizes: [PrizeInfo]) {
+        let prizeInfoObjects = prizes.map {
+            return InputPrizeInfoObject(
+                name: $0.name,
+                prize: $0.prize,
+                prizeAt: $0.prizeAt
+            )
+        }
+        delegate?.completeToInputPrizeInfo(input: prizeInfoObjects)
+    }
+
+    func prizeToggleButtonDidTap(index: Int) {
+        model?.toggleCollapsedProject(index: index)
+    }
+
+    func updatePrizeName(index: Int, name: String) {
+        model?.updatePrizeName(index: index, name: name)
+    }
+
+    func updatePrizePrize(index: Int, prize: String) {
+        model?.updatePrizePrize(index: index, prize: prize)
+    }
+
+    func updatePrizePrizeAt(index: Int, prizeAt: Date) {
+        model?.updatePrizePrizeAt(index: index, prizeAt: prizeAt)
+    }
+
+    func prizePrizeAtDidSelect(index: Int, prizeAt: Date) {
+        model?.updatePrizePrizeAt(index: index, prizeAt: prizeAt)
+    }
+
+    func prizeRemoveButtonDidTap(index: Int) {
+        model?.removePrize(index: index)
+    }
+
+    func appendEmptyPrize() {
+        model?.appendEmptyPrize()
+    }
+
+    func removePrize(index: Int) {
+        model?.removePrize(index: index)
+    }
+
+    func prizeAtButtonDidTap(index: Int) {
+        model?.updateFocusedPrizeIndex(index: index)
+        model?.updateIsPresentedPrizeAtDatePicker(isPresented: true)
+    }
+
+    func prizeAtDismissed() {
+        model?.updateIsPresentedPrizeAtDatePicker(isPresented: false)
+    }
+
+    func prizeAppendButtonDidTap() {
+        model?.appendEmptyPrize()
     }
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
@@ -1,0 +1,15 @@
+import Foundation
+import InputPrizeInfoFeatureInterface
+
+final class InputPrizeInfoIntent: InputPrizeInfoIntentProtocol {
+    private weak var model: (any InputPrizeInfoActionProtocol)?
+    private weak var prizeDelegate: (any InputPrizeDelegate)?
+
+    init(
+        model: any InputPrizeInfoActionProtocol,
+        prizeDelegate: any InputPrizeDelegate
+    ) {
+        self.model = model
+        self.prizeDelegate = prizeDelegate
+    }
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntent.swift
@@ -17,7 +17,7 @@ final class InputPrizeInfoIntent: InputPrizeInfoIntentProtocol {
         delegate?.prizeInfoPrevButtonDidTap()
     }
 
-    func nextButtonDidTap(prizes: [PrizeInfo]) {
+    func completeButtonDidTap(prizes: [PrizeInfo]) {
         let prizeInfoObjects = prizes.map {
             return InputPrizeInfoObject(
                 name: $0.name,

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+protocol InputPrizeInfoIntentProtocol {
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
@@ -1,4 +1,17 @@
 import Foundation
 
 protocol InputPrizeInfoIntentProtocol {
+    func prevButtonDidTap()
+    func nextButtonDidTap(prizes: [PrizeInfo])
+    func prizeToggleButtonDidTap(index: Int)
+    func prizeRemoveButtonDidTap(index: Int)
+    func updatePrizeName(index: Int, name: String)
+    func updatePrizePrize(index: Int, prize: String)
+    func updatePrizePrizeAt(index: Int, prizeAt: Date)
+    func prizePrizeAtDidSelect(index: Int, prizeAt: Date)
+    func appendEmptyPrize()
+    func removePrize(index: Int)
+    func prizeAtButtonDidTap(index: Int)
+    func prizeAtDismissed()
+    func prizeAppendButtonDidTap()
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Intent/InputPrizeInfoIntentProtocol.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol InputPrizeInfoIntentProtocol {
     func prevButtonDidTap()
-    func nextButtonDidTap(prizes: [PrizeInfo])
+    func completeButtonDidTap(prizes: [PrizeInfo])
     func prizeToggleButtonDidTap(index: Int)
     func prizeRemoveButtonDidTap(index: Int)
     func updatePrizeName(index: Int, name: String)

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
@@ -1,7 +1,56 @@
 import Foundation
+import FoundationUtil
 
 final class InputPrizeInfoModel: ObservableObject, InputPrizeInfoStateProtocol {
+    @Published var prizeList: [PrizeInfo] = []
+    @Published var collapsedPrize: [Bool] = []
+    @Published var isPresentedPrizeAtDatePicker: Bool = false
+    var focusedPrizeIndex: Int = 0
 }
 
 extension InputPrizeInfoModel: InputPrizeInfoActionProtocol {
+    func toggleCollapsedProject(index: Int) {
+        guard collapsedPrize[safe: index] != nil else { return }
+        self.collapsedPrize[index].toggle()
+    }
+
+    func updatePrizeName(index: Int, name: String) {
+        guard prizeList[safe: index] != nil else { return }
+        self.prizeList[index].name = name
+    }
+
+    func updatePrizePrize(index: Int, prize: String) {
+        guard prizeList[safe: index] != nil else { return }
+        self.prizeList[index].prize = prize
+    }
+
+    func updatePrizePrizeAt(index: Int, prizeAt: Date) {
+        guard prizeList[safe: index] != nil else { return }
+        self.prizeList[index].prizeAt = prizeAt
+    }
+
+    func appendEmptyPrize() {
+        let newPrize = PrizeInfo(
+            name: "",
+            prize: "",
+            prizeAt: Date()
+        )
+        self.prizeList.append(newPrize)
+        self.collapsedPrize.append(false)
+    }
+
+    func removePrize(index: Int) {
+        guard prizeList[safe: index] != nil, collapsedPrize[safe: index] != nil else { return }
+        self.prizeList.remove(at: index)
+        self.collapsedPrize.remove(at: index)
+    }
+
+    func updateFocusedPrizeIndex(index: Int) {
+        self.focusedPrizeIndex = index
+    }
+
+    func updateIsPresentedPrizeAtDatePicker(isPresented: Bool) {
+        self.isPresentedPrizeAtDatePicker = isPresented
+    }
+
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+final class InputPrizeInfoModel: ObservableObject, InputPrizeInfoStateProtocol {
+}
+
+extension InputPrizeInfoModel: InputPrizeInfoActionProtocol {
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModel.swift
@@ -9,7 +9,7 @@ final class InputPrizeInfoModel: ObservableObject, InputPrizeInfoStateProtocol {
 }
 
 extension InputPrizeInfoModel: InputPrizeInfoActionProtocol {
-    func toggleCollapsedProject(index: Int) {
+    func toggleCollapsedPrize(index: Int) {
         guard collapsedPrize[safe: index] != nil else { return }
         self.collapsedPrize[index].toggle()
     }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
@@ -1,7 +1,30 @@
 import Foundation
+import DateUtil
+
+struct PrizeInfo: Equatable {
+    var name: String
+    var prize: String
+    var prizeAt: Date
+
+    var prizeAtString: String {
+        prizeAt.toStringCustomFormat(format: "yyyy.MM")
+    }
+}
 
 protocol InputPrizeInfoStateProtocol {
+    var prizeList: [PrizeInfo] { get }
+    var collapsedPrize: [Bool] { get }
+    var isPresentedPrizeAtDatePicker: Bool { get }
+    var focusedPrizeIndex: Int { get }
 }
 
 protocol InputPrizeInfoActionProtocol: AnyObject {
+    func toggleCollapsedProject(index: Int)
+    func updatePrizeName(index: Int, name: String)
+    func updatePrizePrize(index: Int, prize: String)
+    func updatePrizePrizeAt(index: Int, prizeAt: Date)
+    func appendEmptyPrize()
+    func removePrize(index: Int)
+    func updateFocusedPrizeIndex(index: Int)
+    func updateIsPresentedPrizeAtDatePicker(isPresented: Bool)
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+protocol InputPrizeInfoStateProtocol {
+}
+
+protocol InputPrizeInfoActionProtocol: AnyObject {
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Model/InputPrizeInfoModelProtocol.swift
@@ -19,7 +19,7 @@ protocol InputPrizeInfoStateProtocol {
 }
 
 protocol InputPrizeInfoActionProtocol: AnyObject {
-    func toggleCollapsedProject(index: Int)
+    func toggleCollapsedPrize(index: Int)
     func updatePrizeName(index: Int, name: String)
     func updatePrizePrize(index: Int, prize: String)
     func updatePrizePrizeAt(index: Int, prizeAt: Date)

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
@@ -43,7 +43,7 @@ struct InputPrizeInfoView: View {
                             .frame(maxWidth: geometry.size.width / 3)
 
                             CTAButton(text: "완료") {
-                                intent.nextButtonDidTap(prizes: state.prizeList)
+                                intent.completeButtonDidTap(prizes: state.prizeList)
                             }
                             .frame(maxWidth: .infinity)
                         }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import BaseFeature
 import DesignSystem
+import InputInformationBaseFeature
 import ViewUtil
 
 struct InputPrizeInfoView: View {
@@ -9,6 +10,37 @@ struct InputPrizeInfoView: View {
     var state: any InputPrizeInfoStateProtocol { container.model }
 
     var body: some View {
-        Text("Adf")
+        SMSNavigationTitleView(title: "수상") {
+            GeometryReader { geometry in
+                ScrollView(showsIndicators: true) {
+                    VStack(spacing: 32) {
+                        SMSSeparator()
+                        InputInformationPageTitleView(title: "프로젝트", isRequired: false, pageCount: 8, selectedPage: 7)
+
+                        VStack(spacing: 24) {
+//                            ForEach(state.projectList.indices, id: \.self) { index in
+//                                projectListRowView(index: index, geometry: geometry)
+//
+//                                SMSSeparator(height: 1)
+//                            }
+                        }
+
+                        SMSChip("추가") {
+                            withAnimation {
+//                                intent.projectAppendButtonDidTap()
+                            }
+                        }
+                        .foregroundColor(.sms(.system(.black)))
+                        .aligned(.trailing)
+
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    func projectListRowView(index: Int, geometry: GeometryProxy) -> some View {
+        
     }
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import BaseFeature
+import DesignSystem
+import ViewUtil
+
+struct InputPrizeInfoView: View {
+    @StateObject var container: MVIContainer<InputPrizeInfoIntentProtocol, InputPrizeInfoStateProtocol>
+    var intent: any InputPrizeInfoIntentProtocol { container.intent }
+    var state: any InputPrizeInfoStateProtocol { container.model }
+
+    var body: some View {
+        Text("Adf")
+    }
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import BaseFeature
 import DesignSystem
 import InputInformationBaseFeature
+import FoundationUtil
+import DateUtil
 import ViewUtil
 
 struct InputPrizeInfoView: View {
@@ -13,34 +15,121 @@ struct InputPrizeInfoView: View {
         SMSNavigationTitleView(title: "수상") {
             GeometryReader { geometry in
                 ScrollView(showsIndicators: true) {
+                    SMSSeparator()
+
                     VStack(spacing: 32) {
-                        SMSSeparator()
-                        InputInformationPageTitleView(title: "프로젝트", isRequired: false, pageCount: 8, selectedPage: 7)
+                        InputInformationPageTitleView(title: "수상", isRequired: false, pageCount: 8, selectedPage: 7)
 
                         VStack(spacing: 24) {
-//                            ForEach(state.projectList.indices, id: \.self) { index in
-//                                projectListRowView(index: index, geometry: geometry)
-//
-//                                SMSSeparator(height: 1)
-//                            }
+                            ForEach(state.prizeList.indices, id: \.self) { index in
+                                prizeListRowView(index: index, geometry: geometry)
+
+                                SMSSeparator(height: 1)
+                            }
                         }
 
                         SMSChip("추가") {
                             withAnimation {
-//                                intent.projectAppendButtonDidTap()
+                                intent.prizeAppendButtonDidTap()
                             }
                         }
                         .foregroundColor(.sms(.system(.black)))
                         .aligned(.trailing)
 
+                        HStack(spacing: 8) {
+                            CTAButton(text: "이전", style: .outline) {
+                                intent.prevButtonDidTap()
+                            }
+                            .frame(maxWidth: geometry.size.width / 3)
+
+                            CTAButton(text: "완료") {
+                                intent.nextButtonDidTap(prizes: state.prizeList)
+                            }
+                            .frame(maxWidth: .infinity)
+                        }
+                        .padding(.bottom, 32)
+
                     }
+                    .padding([.top, .horizontal], 20)
                 }
             }
+        }
+        .datePicker(
+            isShowing: Binding(
+                get: { state.isPresentedPrizeAtDatePicker },
+                set: { _ in intent.prizeAtDismissed() }
+            )
+        ) { date in
+            intent.prizePrizeAtDidSelect(index: state.focusedPrizeIndex, prizeAt: date)
         }
     }
 
     @ViewBuilder
-    func projectListRowView(index: Int, geometry: GeometryProxy) -> some View {
-        
+    func prizeListRowView(index: Int, geometry: GeometryProxy) -> some View {
+        let collapsed = state.collapsedPrize[safe: index] ?? false
+        VStack(alignment: .leading, spacing: 24) {
+            HStack(spacing: 16) {
+                SMSText("프로젝트", font: .title1)
+                    .foregroundColor(.sms(.system(.black)))
+
+                Spacer()
+
+                SMSIcon(.downChevron)
+                    .rotationEffect(collapsed ? .degrees(90) : .degrees(0))
+                    .buttonWrapper {
+                        intent.prizeToggleButtonDidTap(index: index)
+                    }
+
+                SMSIcon(.xmarkOutline)
+                    .buttonWrapper {
+                        intent.prizeRemoveButtonDidTap(index: index)
+                    }
+            }
+            .padding(.bottom, 8)
+
+            ConditionView(!collapsed) {
+                prizeName(index: index)
+
+                prizePrize(index: index)
+
+                prizePrizeAt(index: index)
+            }
+        }
+    }
+}
+
+private extension InputPrizeInfoView {
+    @ViewBuilder
+    func prizeName(index: Int) -> some View {
+        SMSTextField(
+            "수상 내역 이름입력",
+            text: Binding(
+                get: { state.prizeList[safe: index]?.name ?? "" },
+                set: { intent.updatePrizeName(index: index, name: $0) }
+            )
+        )
+        .titleWrapper("이름")
+    }
+
+    @ViewBuilder
+    func prizePrize(index: Int) -> some View {
+        SMSTextField(
+            "수상 종류입력",
+            text: Binding(
+                get: { state.prizeList[safe: index]?.prize ?? "" },
+                set: { intent.updatePrizePrize(index: index, prize: $0)}
+            )
+        )
+        .titleWrapper("종류")
+    }
+
+    @ViewBuilder
+    func prizePrizeAt(index: Int) -> some View {
+        let prize = state.prizeList[safe: index]
+        DatePickerField(dateText: prize?.prizeAtString ?? "") {
+            intent.prizeAtButtonDidTap(index: index)
+        }
+        .frame(maxWidth: .infinity)
+        .titleWrapper("기간")
     }
 }

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/InputPrizeInfoView.swift
@@ -69,7 +69,7 @@ struct InputPrizeInfoView: View {
         let collapsed = state.collapsedPrize[safe: index] ?? false
         VStack(alignment: .leading, spacing: 24) {
             HStack(spacing: 16) {
-                SMSText("프로젝트", font: .title1)
+                SMSText("수상", font: .title1)
                     .foregroundColor(.sms(.system(.black)))
 
                 Spacer()

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/View/DatePickerField.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/View/DatePickerField.swift
@@ -1,0 +1,9 @@
+//
+//  DatePickerField.swift
+//  InputPrizeInfoFeatureInterface
+//
+//  Created by sunghun on 8/1/23.
+//  Copyright © 2023 com.msg. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/View/DatePickerField.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Sources/Scene/View/DatePickerField.swift
@@ -1,9 +1,37 @@
-//
-//  DatePickerField.swift
-//  InputPrizeInfoFeatureInterface
-//
-//  Created by sunghun on 8/1/23.
-//  Copyright © 2023 com.msg. All rights reserved.
-//
+import DesignSystem
+import SwiftUI
 
-import Foundation
+struct DatePickerField: View {
+    let dateText: String
+    let action: () -> Void
+
+    init(
+        dateText: String,
+        action: @escaping () -> Void
+    ) {
+        self.dateText = dateText
+        self.action = action
+    }
+
+    var body: some View {
+        SMSTextField(
+            "yyyy.mm",
+            text: Binding(
+                get: { dateText },
+                set: { _ in }
+            ),
+            isOnClear: false
+        )
+        .disabled(true)
+        .overlay(alignment: .trailing) {
+            SMSIcon(.calendar)
+                .padding(.trailing, 12)
+        }
+        .simultaneousGesture(
+            TapGesture()
+                .onEnded {
+                    action()
+                }
+        )
+    }
+}

--- a/Projects/Feature/InputPrizeInfoFeature/Tests/InputPrizeInfoFeatureTest.swift
+++ b/Projects/Feature/InputPrizeInfoFeature/Tests/InputPrizeInfoFeatureTest.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class InputPrizeInfoFeatureTests: XCTestCase {
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testExample() {
+        XCTAssertEqual(1, 1)
+    }
+}

--- a/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
+++ b/Projects/Feature/InputProfileInfoFeature/Sources/Scene/InputProfileInfoView.swift
@@ -34,7 +34,7 @@ struct InputProfileInfoView: View {
                     SMSSeparator()
 
                     VStack(spacing: 32) {
-                        InputInformationPageTitleView(title: "프로필", pageCount: 7, selectedPage: 0)
+                        InputInformationPageTitleView(title: "프로필", pageCount: 8, selectedPage: 0)
 
                         VStack(alignment: .leading, spacing: 24) {
                             VStack(alignment: .leading, spacing: 8) {

--- a/Projects/Feature/InputProjectInfoFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Demo/Sources/AppDelegate.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import InputProjectInfoFeatureInterface
 import TechStackAppendFeatureInterface
 @testable import InputProjectInfoFeature
+@testable import FileDomainTesting
 
 final class DummyInputProjectInfoDelegate: InputProjectInfoDelegate {
     func projectInfoPrevButtonDidTap() {}
@@ -17,12 +18,14 @@ struct DummyTechStackAppendBuildable: TechStackAppendBuildable {
 
 @main
 struct InputProjectInfoApp: App {
+    var imageUploadUseCaseSpy: ImageUploadUseCaseSpy!
+
     var body: some Scene {
         WindowGroup {
             let model = InputProjectInfoModel()
             let intent = InputProjectInfoIntent(
                 model: model,
-                delegate: DummyInputProjectInfoDelegate()
+                delegate: DummyInputProjectInfoDelegate(), imageUploadUseCase: imageUploadUseCaseSpy
             )
             let container = MVIContainer(
                 intent: intent as InputProjectInfoIntentProtocol,

--- a/Projects/Feature/InputProjectInfoFeature/Interface/InputProjectInfoDelegate.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Interface/InputProjectInfoDelegate.swift
@@ -1,4 +1,6 @@
 import Foundation
+import StudentDomainInterface
+import DateUtil
 
 public protocol InputProjectInfoDelegate: AnyObject {
     func projectInfoPrevButtonDidTap()
@@ -40,12 +42,41 @@ public struct InputProjectInfoObject {
 }
 
 public extension InputProjectInfoObject {
+    var startAtString: String {
+        startAt.toStringCustomFormat(format: "yyyy.MM")
+    }
+    var endAtString: String {
+        endAt?.toStringCustomFormat(format: "yyyy.MM") ?? ""
+    }
+
+    func toDTO() -> InputStudentInformationRequestDTO.Project {
+        InputStudentInformationRequestDTO.Project(
+            name: name,
+            iconImageURL: iconImage?.url ?? "",
+            previewImageURLs: previewImages.map { $0.previewImageUrl ?? "" },
+            description: content,
+            links: relatedLinks.map { $0.toDTO() },
+            techStacks: techStacks,
+            myActivity: mainTask,
+            inProgress: InputStudentInformationRequestDTO.Project.InProgress(
+                start: startAtString,
+                end: endAtString
+            )
+        )
+    }
+}
+
+public extension InputProjectInfoObject {
     struct ImageFile {
         public let name: String
+        public let url: String?
+        public let previewImageUrl: String?
         public let data: Data
 
-        public init(name: String, data: Data) {
+        public init(name: String, url: String? = .init(), previewImageUrl: String? = .init(), data: Data) {
             self.name = name
+            self.url = url
+            self.previewImageUrl = previewImageUrl
             self.data = data
         }
     }
@@ -58,5 +89,14 @@ public extension InputProjectInfoObject {
             self.name = name
             self.url = url
         }
+    }
+}
+
+extension InputProjectInfoObject.RelatedLink {
+    func toDTO() -> InputStudentInformationRequestDTO.Project.Link {
+        InputStudentInformationRequestDTO.Project.Link(
+            name: name,
+            url: url
+        )
     }
 }

--- a/Projects/Feature/InputProjectInfoFeature/Project.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Project.swift
@@ -9,6 +9,10 @@ let project = Project.makeModule(
     internalDependencies: [
         .Feature.InputInformationBaseFeature,
         .Feature.TechStackAppendFeatureInterface,
-        .Feature.InputPrizeInfoFeatureInterface
+        .Feature.InputPrizeInfoFeatureInterface,
+        .Domain.StudentDomainInterface,
+        .Domain.FileDomainInterface,
+        .Domain.FileDomainTesting,
+        .Shared.ConcurrencyUtil
     ]
 )

--- a/Projects/Feature/InputProjectInfoFeature/Project.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project.makeModule(
     targets: [.interface, .unitTest, .demo],
     internalDependencies: [
         .Feature.InputInformationBaseFeature,
-        .Feature.TechStackAppendFeatureInterface
+        .Feature.TechStackAppendFeatureInterface,
+        .Feature.InputPrizeInfoFeatureInterface
     ]
 )

--- a/Projects/Feature/InputProjectInfoFeature/Sources/DI/InputProjectInfoComponent.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Sources/DI/InputProjectInfoComponent.swift
@@ -3,9 +3,11 @@ import InputProjectInfoFeatureInterface
 import NeedleFoundation
 import SwiftUI
 import TechStackAppendFeatureInterface
+import FileDomainInterface
 
 public protocol InputProjectInfoDependency: Dependency {
     var techStackAppendBuildable: any TechStackAppendBuildable { get }
+    var fileDomainBuildable: any FileDomainBuildable { get }
 }
 
 public final class InputProjectInfoComponent:
@@ -15,7 +17,8 @@ public final class InputProjectInfoComponent:
         let model = InputProjectInfoModel()
         let intent = InputProjectInfoIntent(
             model: model,
-            delegate: delegate
+            delegate: delegate,
+            imageUploadUseCase: dependency.fileDomainBuildable.imageUploadUseCase
         )
         let container = MVIContainer(
             intent: intent as InputProjectInfoIntentProtocol,

--- a/Projects/Feature/InputProjectInfoFeature/Sources/Scene/InputProjectInfoView.swift
+++ b/Projects/Feature/InputProjectInfoFeature/Sources/Scene/InputProjectInfoView.swift
@@ -29,7 +29,7 @@ struct InputProjectInfoView: View {
                     SMSSeparator()
 
                     VStack(spacing: 32) {
-                        InputInformationPageTitleView(title: "프로젝트", isRequired: false, pageCount: 7, selectedPage: 6)
+                        InputInformationPageTitleView(title: "프로젝트", isRequired: false, pageCount: 8, selectedPage: 6)
 
                         VStack(spacing: 24) {
                             ForEach(state.projectList.indices, id: \.self) { index in

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/Scene/InputSchoolLifeInfoView.swift
@@ -15,7 +15,7 @@ struct InputSchoolLifeInfoView: View {
                 SMSSeparator()
 
                 VStack(spacing: 32) {
-                    InputInformationPageTitleView(title: "학교 생활", pageCount: 7, selectedPage: 1)
+                    InputInformationPageTitleView(title: "학교 생활", pageCount: 8, selectedPage: 1)
 
                     VStack(spacing: 24) {
                         SMSTextField(

--- a/Projects/Feature/InputWorkInfoFeature/Sources/Scene/InputWorkInfoView.swift
+++ b/Projects/Feature/InputWorkInfoFeature/Sources/Scene/InputWorkInfoView.swift
@@ -18,7 +18,7 @@ struct InputWorkInfoView: View {
                     SMSSeparator()
 
                     VStack(spacing: 32) {
-                        InputInformationPageTitleView(title: "근무 조건", pageCount: 7, selectedPage: 2)
+                        InputInformationPageTitleView(title: "근무 조건", pageCount: 8, selectedPage: 2)
 
                         VStack(spacing: 24) {
                             SMSTextField(

--- a/Projects/Shared/ConcurrencyUtil/Project.swift
+++ b/Projects/Shared/ConcurrencyUtil/Project.swift
@@ -1,0 +1,10 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePaths.Shared.��ConcurrencyUtil.rawValue,
+    product: .staticLibrary,
+    targets: [],
+    internalDependencies: []
+)

--- a/Projects/Shared/ConcurrencyUtil/Project.swift
+++ b/Projects/Shared/ConcurrencyUtil/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescriptionHelpers
 import DependencyPlugin
 
 let project = Project.makeModule(
-    name: ModulePaths.Shared.��ConcurrencyUtil.rawValue,
+    name: ModulePaths.Shared.ConcurrencyUtil.rawValue,
     product: .staticLibrary,
     targets: [],
     internalDependencies: []

--- a/Projects/Shared/ConcurrencyUtil/Sources/Task+Concurrency.swift
+++ b/Projects/Shared/ConcurrencyUtil/Sources/Task+Concurrency.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public extension Sequence {
+    func asyncMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+
+        for element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+
+    func concurrentMap<T>(
+        _ transform: @escaping (Element) async throws -> T
+    ) async throws -> [T] {
+        let tasks = map { element in
+            Task {
+                try await transform(element)
+            }
+        }
+
+        return try await tasks.asyncMap { task in
+            try await task.value
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요
수상 정보 입력 추가

## 📃 작업내용
수상 정보 입력 추가를 만들었습니다
<img src="https://github.com/GSM-MSG/SMS-iOS/assets/81547954/ec4fcba7-7256-4161-a908-ac1caa33d10b" width="300">

## 🔀 변경사항
* InputProjectInfoIntent 에서 파일 업로드 추가
* StudentRequestDTO에 init 추가
* concurrencyUtil 모듈 추가

## 🙋‍♂️ 질문사항
수상 종류는 Prize라고 명하긴 했는데 이름을 PrizeType으로 변경을 하는게 좋을까요 아니면 다른 이름을 변경해 주는게 좋을까요?
PrizeAt도 똑같이 DateAt으로 변경할지 다른 이름으로 변경할지 고민입니다

## 🎸 기타
🎸