### PR TITLE
🔀 :: [#255] BaseDomain XCConfig 연결

### DIFF
--- a/Projects/Domain/BaseDomain/Project.swift
+++ b/Projects/Domain/BaseDomain/Project.swift
@@ -2,8 +2,18 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 import DependencyPlugin
 
+let name = ModulePaths.Domain.BaseDomain.rawValue
+
+let configurations: [Configuration] = generateEnvironment == .ci ?
+    .default :
+    [
+        .debug(name: .dev, xcconfig: .relativeToXCConfig(type: .dev, name: name)),
+        .debug(name: .stage, xcconfig: .relativeToXCConfig(type: .stage, name: name)),
+        .release(name: .prod, xcconfig: .relativeToXCConfig(type: .prod, name: name))
+    ]
+
 let project = Project.makeModule(
-    name: ModulePaths.Domain.BaseDomain.rawValue,
+    name: name,
     product: .framework,
     targets: [.unitTest],
     externalDependencies: [
@@ -19,5 +29,6 @@ let project = Project.makeModule(
     ],
     additionalPlistRows: [
         "BASE_URL": .string("$(BASE_URL)")
-    ]
+    ],
+    configurations: configurations
 )


### PR DESCRIPTION
## 💡 개요
- CD를 구축하느라 XCConfig 연결 시스템이 바뀌었는데, BaseDomain이 Shared.xcconfig만 참조한 상태
- BaseDomain이 전용 xcconfig를 가져가도록 변경

## 📃 작업내용
- BaseDomain이 전용 xcconfig를 가져가도록 변경
