### PR TITLE
🔀 :: [#296] 기술스택 글자 수 30자 제한

### DIFF
--- a/Projects/Feature/TechStackAppendFeature/Sources/Intent/TechStackAppendIntent.swift
+++ b/Projects/Feature/TechStackAppendFeature/Sources/Intent/TechStackAppendIntent.swift
@@ -1,6 +1,7 @@
 import EventLimiter
 import Foundation
 import TechStackDomainInterface
+import Validator
 
 final class TechStackAppendIntent: TechStackAppendIntentProtocol {
     private let model: (any TechStackAppendActionProtocol)?
@@ -19,6 +20,8 @@ final class TechStackAppendIntent: TechStackAppendIntentProtocol {
     }
 
     func updateSearchText(text: String) {
+        let stringSizeValidator = StringSizeValidator(min: 0, max: 30)
+        guard stringSizeValidator.validate(text) else { return }
         model?.updateSearchText(text: text)
         debouncer { [weak self] in
             guard let self else { return }


### PR DESCRIPTION
## 💡 개요
기술스택 글자 수 30자 제한

## 📃 작업내용
- TechStackAppendIntent의 Text가 입력될 때 최대 글자 수 validation