### PR TITLE
🔀 :: [#313] Needle에서 parent compnent로부터 주입을 못받는 현상을 해결해요

### DIFF
--- a/Projects/App/Sources/Application/DI/AppComponent.swift
+++ b/Projects/App/Sources/Application/DI/AppComponent.swift
@@ -56,103 +56,103 @@ final class AppComponent: BootstrapComponent {
         rootComponent.makeView()
     }
 
-    var rootComponent: RootComponent {
+    public var rootComponent: RootComponent {
         RootComponent(parent: self)
     }
 
-    var signinBuildable: any SigninBuildable {
+    public var signinBuildable: any SigninBuildable {
         SigninComponent(parent: self)
     }
 
-    var inputInformationBuildable: any InputInformationBuildable {
+    public var inputInformationBuildable: any InputInformationBuildable {
         InputInformationComponent(parent: self)
     }
 
-    var inputProfileInfoBuildable: any InputProfileInfoBuildable {
+    public var inputProfileInfoBuildable: any InputProfileInfoBuildable {
         InputProfileInfoComponent(parent: self)
     }
 
-    var inputSchoolLifeInfoBuildable: any InputSchoolListInfoBuildable {
+    public var inputSchoolLifeInfoBuildable: any InputSchoolLifeInfoBuildable {
         InputSchoolLifeInfoComponent(parent: self)
     }
 
-    var inputWorkInfoBuildable: any InputWorkInfoBuildable {
+    public var inputWorkInfoBuildable: any InputWorkInfoBuildable {
         InputWorkInfoComponent(parent: self)
     }
 
-    var inputMilitaryInfoBuildable: any InputMilitaryInfoBuildable {
+    public var inputMilitaryInfoBuildable: any InputMilitaryInfoBuildable {
         InputMilitaryInfoComponent(parent: self)
     }
 
-    var inputCertificateInfoBuildable: any InputCertificateInfoBuildable {
+    public var inputCertificateInfoBuildable: any InputCertificateInfoBuildable {
         InputCertificateInfoComponent(parent: self)
     }
 
-    var inputLanguageInfoBuildable: any InputLanguageInfoBuildable {
+    public var inputLanguageInfoBuildable: any InputLanguageInfoBuildable {
         InputLanguageInfoComponent(parent: self)
     }
 
-    var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
+    public var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
         InputPrizeInfoComponent(parent: self)
     }
 
-    var inputProjectInfoBuildable: any InputProjectInfoBuildable {
+    public var inputProjectInfoBuildable: any InputProjectInfoBuildable {
         InputProjectInfoComponent(parent: self)
     }
 
-    var mainBuildable: any MainBuildable {
+    public var mainBuildable: any MainBuildable {
         MainComponent(parent: self)
     }
 
-    var myPageBuildable: any MyPageBuildable {
+    public var myPageBuildable: any MyPageBuildable {
         MyPageComponent(parent: self)
     }
 
-    var techStackAppendBuildable: any TechStackAppendBuildable {
+    public var techStackAppendBuildable: any TechStackAppendBuildable {
         TechStackAppendComponent(parent: self)
     }
 
-    var studentDetailBuildable: any StudentDetailBuildable {
+    public var studentDetailBuildable: any StudentDetailBuildable {
         StudentDetailComponent(parent: self)
     }
 
-    var filterBuildable: any FilterBuildable {
+    public var filterBuildable: any FilterBuildable {
         FilterComponent(parent: self)
     }
 
-    var splashBuildable: any SplashBuildable {
+    public var splashBuildable: any SplashBuildable {
         SplashComponent(parent: self)
     }
 
-    var authDomainBuildable: any AuthDomainBuildable {
+    public var authDomainBuildable: any AuthDomainBuildable {
         AuthDomainComponent(parent: self)
     }
 
-    var studentDomainBuildable: any StudentDomainBuildable {
+    public var studentDomainBuildable: any StudentDomainBuildable {
         StudentDomainComponent(parent: self)
     }
 
-    var majorDomainBuildable: any MajorDomainBuildable {
+    public var majorDomainBuildable: any MajorDomainBuildable {
         MajorDomainComponent(parent: self)
     }
 
-    var fileDomainBuildable: any FileDomainBuildable {
+    public var fileDomainBuildable: any FileDomainBuildable {
         FileDomainComponent(parent: self)
     }
 
-    var userDomainBuildable: any UserDomainBuildable {
+    public var userDomainBuildable: any UserDomainBuildable {
         UserDomainComponent(parent: self)
     }
 
-    var techStackDomainBuildable: any TechStackDomainBuildable {
+    public var techStackDomainBuildable: any TechStackDomainBuildable {
         TechStackDomainComponent(parent: self)
     }
 
-    var jwtStoreBuildable: any JwtStoreBuildable {
+    public var jwtStoreBuildable: any JwtStoreBuildable {
         JwtStoreComponent(parent: self)
     }
 
-    var keychainBuildable: any KeychainBuildable {
+    public var keychainBuildable: any KeychainBuildable {
         KeychainComponent(parent: self)
     }
 }

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -278,27 +278,6 @@ private class InputInformationDependency7b32a8e7e8a8f0ab5466Provider: InputInfor
     var inputProfileInfoBuildable: any InputProfileInfoBuildable {
         return appComponent.inputProfileInfoBuildable
     }
-    var inputSchoolLifeInfoBuildable: any InputSchoolListInfoBuildable {
-        return appComponent.inputSchoolLifeInfoBuildable
-    }
-    var inputWorkInfoBuildable: any InputWorkInfoBuildable {
-        return appComponent.inputWorkInfoBuildable
-    }
-    var inputMilitaryInfoBuildable: any InputMilitaryInfoBuildable {
-        return appComponent.inputMilitaryInfoBuildable
-    }
-    var inputCertificateInfoBuildable: any InputCertificateInfoBuildable {
-        return appComponent.inputCertificateInfoBuildable
-    }
-    var inputLanguageInfoBuildable: any InputLanguageInfoBuildable {
-        return appComponent.inputLanguageInfoBuildable
-    }
-    var inputProjectInfoBuildable: any InputProjectInfoBuildable {
-        return appComponent.inputProjectInfoBuildable
-    }
-    var inputPrizeInfoBuildable: any InputPrizeInfoBuildable {
-        return appComponent.inputPrizeInfoBuildable
-    }
     var fileDomainBuildable: any FileDomainBuildable {
         return appComponent.fileDomainBuildable
     }
@@ -456,7 +435,31 @@ extension JwtStoreComponent: Registration {
 extension AppComponent: Registration {
     public func registerItems() {
 
-
+        localTable["rootComponent-RootComponent"] = { [unowned self] in self.rootComponent as Any }
+        localTable["signinBuildable-any SigninBuildable"] = { [unowned self] in self.signinBuildable as Any }
+        localTable["inputInformationBuildable-any InputInformationBuildable"] = { [unowned self] in self.inputInformationBuildable as Any }
+        localTable["inputProfileInfoBuildable-any InputProfileInfoBuildable"] = { [unowned self] in self.inputProfileInfoBuildable as Any }
+        localTable["inputSchoolLifeInfoBuildable-any InputSchoolLifeInfoBuildable"] = { [unowned self] in self.inputSchoolLifeInfoBuildable as Any }
+        localTable["inputWorkInfoBuildable-any InputWorkInfoBuildable"] = { [unowned self] in self.inputWorkInfoBuildable as Any }
+        localTable["inputMilitaryInfoBuildable-any InputMilitaryInfoBuildable"] = { [unowned self] in self.inputMilitaryInfoBuildable as Any }
+        localTable["inputCertificateInfoBuildable-any InputCertificateInfoBuildable"] = { [unowned self] in self.inputCertificateInfoBuildable as Any }
+        localTable["inputLanguageInfoBuildable-any InputLanguageInfoBuildable"] = { [unowned self] in self.inputLanguageInfoBuildable as Any }
+        localTable["inputPrizeInfoBuildable-any InputPrizeInfoBuildable"] = { [unowned self] in self.inputPrizeInfoBuildable as Any }
+        localTable["inputProjectInfoBuildable-any InputProjectInfoBuildable"] = { [unowned self] in self.inputProjectInfoBuildable as Any }
+        localTable["mainBuildable-any MainBuildable"] = { [unowned self] in self.mainBuildable as Any }
+        localTable["myPageBuildable-any MyPageBuildable"] = { [unowned self] in self.myPageBuildable as Any }
+        localTable["techStackAppendBuildable-any TechStackAppendBuildable"] = { [unowned self] in self.techStackAppendBuildable as Any }
+        localTable["studentDetailBuildable-any StudentDetailBuildable"] = { [unowned self] in self.studentDetailBuildable as Any }
+        localTable["filterBuildable-any FilterBuildable"] = { [unowned self] in self.filterBuildable as Any }
+        localTable["splashBuildable-any SplashBuildable"] = { [unowned self] in self.splashBuildable as Any }
+        localTable["authDomainBuildable-any AuthDomainBuildable"] = { [unowned self] in self.authDomainBuildable as Any }
+        localTable["studentDomainBuildable-any StudentDomainBuildable"] = { [unowned self] in self.studentDomainBuildable as Any }
+        localTable["majorDomainBuildable-any MajorDomainBuildable"] = { [unowned self] in self.majorDomainBuildable as Any }
+        localTable["fileDomainBuildable-any FileDomainBuildable"] = { [unowned self] in self.fileDomainBuildable as Any }
+        localTable["userDomainBuildable-any UserDomainBuildable"] = { [unowned self] in self.userDomainBuildable as Any }
+        localTable["techStackDomainBuildable-any TechStackDomainBuildable"] = { [unowned self] in self.techStackDomainBuildable as Any }
+        localTable["jwtStoreBuildable-any JwtStoreBuildable"] = { [unowned self] in self.jwtStoreBuildable as Any }
+        localTable["keychainBuildable-any KeychainBuildable"] = { [unowned self] in self.keychainBuildable as Any }
     }
 }
 extension KeychainComponent: Registration {
@@ -542,13 +545,6 @@ extension TechStackAppendComponent: Registration {
 extension InputInformationComponent: Registration {
     public func registerItems() {
         keyPathToName[\InputInformationDependency.inputProfileInfoBuildable] = "inputProfileInfoBuildable-any InputProfileInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputSchoolLifeInfoBuildable] = "inputSchoolLifeInfoBuildable-any InputSchoolListInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputWorkInfoBuildable] = "inputWorkInfoBuildable-any InputWorkInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputMilitaryInfoBuildable] = "inputMilitaryInfoBuildable-any InputMilitaryInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputCertificateInfoBuildable] = "inputCertificateInfoBuildable-any InputCertificateInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputLanguageInfoBuildable] = "inputLanguageInfoBuildable-any InputLanguageInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputProjectInfoBuildable] = "inputProjectInfoBuildable-any InputProjectInfoBuildable"
-        keyPathToName[\InputInformationDependency.inputPrizeInfoBuildable] = "inputPrizeInfoBuildable-any InputPrizeInfoBuildable"
         keyPathToName[\InputInformationDependency.fileDomainBuildable] = "fileDomainBuildable-any FileDomainBuildable"
         keyPathToName[\InputInformationDependency.studentDomainBuildable] = "studentDomainBuildable-any StudentDomainBuildable"
     }
@@ -620,7 +616,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
 
 #if !NEEDLE_DYNAMIC
 
-private func register1() {
+@inline(never) private func register1() {
     registerProviderFactory("^->AppComponent->JwtStoreComponent", factoryb27d5aae1eb7e73575a6f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent", factoryEmptyDependencyProvider)
     registerProviderFactory("^->AppComponent->KeychainComponent", factoryEmptyDependencyProvider)

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Interface/InputSchoolLifeInfoBuildable.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Interface/InputSchoolLifeInfoBuildable.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public protocol InputSchoolListInfoBuildable {
+public protocol InputSchoolLifeInfoBuildable {
     associatedtype ViewType: View
     func makeView(delegate: any InputSchoolLifeDelegate) -> ViewType
 }

--- a/Projects/Feature/InputSchoolLifeInfoFeature/Sources/DI/InputSchoolLifeInfoComponent.swift
+++ b/Projects/Feature/InputSchoolLifeInfoFeature/Sources/DI/InputSchoolLifeInfoComponent.swift
@@ -7,7 +7,7 @@ public protocol InputSchoolLifeInfoDependency: Dependency {}
 
 public final class InputSchoolLifeInfoComponent:
     Component<InputSchoolLifeInfoDependency>,
-    InputSchoolListInfoBuildable {
+    InputSchoolLifeInfoBuildable {
 
     public func makeView(delegate: any InputSchoolLifeDelegate) -> some View {
         let model = InputSchoolLifeInfoModel()


### PR DESCRIPTION
## 💡 개요
![image](https://github.com/GSM-MSG/SMS-iOS/assets/74440939/fb735992-5d05-4cbd-b912-fa37000ae7a2)

Needle 스크립트를 돌리면 parent compnent로부터 주입을 못받아서 빌드가 실패가 나는 현상이 발견되었어요.

https://github.com/uber/needle/releases/tag/v0.24.0
needle의 최신 릴리즈를 보니 의존성을 내려줄때 internal 접근 제한자는 무시해요.

=> 주입을 위한 프로퍼티는 모두 public 접근 제한자를 붙여주어요.

## 📃 작업내용
Needle 최신 버전 변경사항 반영

## 🔀 변경사항
AppComponent의 register를 위한 의존성은 모두 public 접근 제한자 설정
