### PR TITLE
🔀 :: [#315] 선생님 정보입력 페이지 UI

### DIFF
--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
@@ -9,6 +9,14 @@ public extension TargetDependency {
 }
 
 public extension TargetDependency.Feature {
+    static let InputTeacherInfoFeatureInterface = TargetDependency.project(
+        target: ModulePaths.Feature.InputTeacherInfoFeature.targetName(type: .interface),
+        path: .relativeToFeature(ModulePaths.Feature.InputTeacherInfoFeature.rawValue)
+    )
+    static let InputTeacherInfoFeature = TargetDependency.project(
+        target: ModulePaths.Feature.InputTeacherInfoFeature.targetName(type: .sources),
+        path: .relativeToFeature(ModulePaths.Feature.InputTeacherInfoFeature.rawValue)
+    )
     static let InputPrizeInfoFeatureInterface = TargetDependency.project(
         target: ModulePaths.Feature.InputPrizeInfoFeature.targetName(type: .interface),
         path: .relativeToFeature(ModulePaths.Feature.InputPrizeInfoFeature.rawValue)

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
@@ -10,6 +10,7 @@ public enum ModulePaths {
 
 public extension ModulePaths {
     enum Feature: String {
+        case InputTeacherInfoFeature
         case InputPrizeInfoFeature
         case MyPageFeature
         case InputProjectInfoFeature

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -46,6 +46,7 @@ let targets: [Target] = [
             .Feature.InputCertificateInfoFeature,
             .Feature.InputLanguageInfoFeature,
             .Feature.InputProjectInfoFeature,
+            .Feature.InputTeacherInfoFeature,
             .Feature.MainFeature,
             .Feature.SplashFeature,
             .Feature.TechStackAppendFeature,

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -25,6 +25,7 @@ import InputProjectInfoFeature
 import InputProjectInfoFeatureInterface
 import InputSchoolLifeInfoFeature
 import InputSchoolLifeInfoFeatureInterface
+import InputTeacherInfoFeatureInterface
 import InputWorkInfoFeature
 import InputWorkInfoFeatureInterface
 import JwtStore

--- a/Projects/Feature/InputTeacherInfoFeature/Demo/Resources/LaunchScreen.storyboard
+++ b/Projects/Feature/InputTeacherInfoFeature/Demo/Resources/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .yellow
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+
+        return true
+    }
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
@@ -1,11 +1,27 @@
+import BaseFeature
 import SwiftUI
+import InputTeacherInfoFeatureInterface
 @testable import InputTeacherInfoFeature
+
+final class DummyInputTeacherInfoDelegate: InputTeacherDelegate {
+    func completeToInputTeacherInformation() {}
+}
 
 @main
 struct InputTeacherInfoApp: App {
     var body: some Scene {
         WindowGroup {
-            InputTeacherInfoView()
+            let model = InputTeacherInfoModel()
+            let intent = InputTeacherInfoIntent(
+                model: model,
+                teacherDelegate: DummyInputTeacherInfoDelegate()
+            )
+            let container = MVIContainer(
+                intent: intent as InputTeacherInfoIntentProtocol,
+                model: model as InputTeacherInfoStateProtocol,
+                modelChangePublisher: model.objectWillChange
+            )
+            InputTeacherInfoView(container: container)
         }
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Demo/Sources/AppDelegate.swift
@@ -1,19 +1,11 @@
-import UIKit
+import SwiftUI
+@testable import InputTeacherInfoFeature
 
 @main
-final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-    ) -> Bool {
-        window = UIWindow(frame: UIScreen.main.bounds)
-        let viewController = UIViewController()
-        viewController.view.backgroundColor = .yellow
-        window?.rootViewController = viewController
-        window?.makeKeyAndVisible()
-
-        return true
+struct InputTeacherInfoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            InputTeacherInfoView()
+        }
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherDelegate.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherDelegate.swift
@@ -1,0 +1,3 @@
+public protocol InputTeacherDelegate: AnyObject {
+    func completeToInputTeacherInformation()
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherInfoBuildable.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherInfoBuildable.swift
@@ -2,5 +2,5 @@ import SwiftUI
 
 public protocol InputTeacherInfoBuildable {
     associatedtype ViewType: View
-    func makeView() -> ViewType
+    func makeView(delegate: InputTeacherDelegate) -> ViewType
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherInfoBuildable.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Interface/InputTeacherInfoBuildable.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+public protocol InputTeacherInfoBuildable {
+    associatedtype ViewType: View
+    func makeView() -> ViewType
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Interface/Interface.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Interface/Interface.swift
@@ -1,1 +1,0 @@
-// This is for Tuist

--- a/Projects/Feature/InputTeacherInfoFeature/Interface/Interface.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Interface/Interface.swift
@@ -1,0 +1,1 @@
+// This is for Tuist

--- a/Projects/Feature/InputTeacherInfoFeature/Project.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Project.swift
@@ -5,8 +5,6 @@ import DependencyPlugin
 let project = Project.makeModule(
     name: ModulePaths.Feature.InputTeacherInfoFeature.rawValue,
     product: .staticLibrary,
-    targets: [.interface, .unitTest],
-    internalDependencies: [
-        .Feature.InputInformationBaseFeature
-    ]
+    targets: [.interface, .unitTest, .demo],
+    internalDependencies: []
 )

--- a/Projects/Feature/InputTeacherInfoFeature/Project.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Project.swift
@@ -6,5 +6,7 @@ let project = Project.makeModule(
     name: ModulePaths.Feature.InputTeacherInfoFeature.rawValue,
     product: .staticLibrary,
     targets: [.interface, .unitTest, .demo],
-    internalDependencies: []
+    internalDependencies: [
+        .Feature.BaseFeature
+    ]
 )

--- a/Projects/Feature/InputTeacherInfoFeature/Project.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Project.swift
@@ -7,6 +7,7 @@ let project = Project.makeModule(
     product: .staticLibrary,
     targets: [.interface, .unitTest, .demo],
     internalDependencies: [
-        .Feature.BaseFeature
+        .Feature.BaseFeature,
+        .Feature.InputInformationBaseFeature
     ]
 )

--- a/Projects/Feature/InputTeacherInfoFeature/Project.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePaths.Feature.InputTeacherInfoFeature.rawValue,
+    product: .staticLibrary,
+    targets: [.interface, .unitTest],
+    internalDependencies: [
+        .Feature.InputInformationBaseFeature
+    ]
+)

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -1,0 +1,13 @@
+import BaseFeature
+import InputTeacherInfoFeatureInterface
+import NeedleFoundation
+import SwiftUI
+
+public protocol InputTeacherInfoDependency: Dependency {}
+
+public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
+    
+    public func makeView() -> some View {
+        EmptyView()
+    }
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -7,7 +7,14 @@ public protocol InputTeacherInfoDependency: Dependency {}
 
 public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
 
-    public func makeView() -> some View {
-        EmptyView()
+    public func makeView(delegate: InputTeacherDelegate) -> some View {
+        let model = InputTeacherInfoModel()
+        let intent = InputTeacherInfoIntent(model: model, teacherDelegate: delegate)
+        let container = MVIContainer(
+            intent: intent as InputTeacherInfoIntentProtocol,
+            model: model as InputTeacherInfoStateProtocol,
+            modelChangePublisher: model.objectWillChange
+        )
+        return InputTeacherInfoView(container: container)
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public protocol InputTeacherInfoDependency: Dependency {}
 
 public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
-    
+
     public func makeView() -> some View {
         EmptyView()
     }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -3,7 +3,9 @@ import InputTeacherInfoFeatureInterface
 import NeedleFoundation
 import SwiftUI
 
-public protocol InputTeacherInfoDependency: Dependency {}
+public protocol InputTeacherInfoDependency: Dependency {
+    
+}
 
 public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
 

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -3,20 +3,11 @@ import InputTeacherInfoFeatureInterface
 import NeedleFoundation
 import SwiftUI
 
-public protocol InputTeacherInfoDependency: Dependency {
-    
-}
+public protocol InputTeacherInfoDependency: Dependency {}
 
 public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
 
     public func makeView() -> some View {
-        let model = InputTeacherInfoModel()
-        let intent = InputTeacherInfoIntent(model: model)
-        let container = MVIContainer(
-            intent: intent as InputTeacherInfoIntentProtocol,
-            model: model as InputTeacherInfoStateProtocol,
-            modelChangePublisher: model.objectWillChange
-        )
-        return InputTeacherInfoView(container: container)
+        EmptyView()
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/DI/InputTeacherInfoComponent.swift
@@ -8,6 +8,13 @@ public protocol InputTeacherInfoDependency: Dependency {}
 public final class InputTeacherInfoComponent: Component<InputTeacherInfoDependency>, InputTeacherInfoBuildable {
 
     public func makeView() -> some View {
-        EmptyView()
+        let model = InputTeacherInfoModel()
+        let intent = InputTeacherInfoIntent(model: model)
+        let container = MVIContainer(
+            intent: intent as InputTeacherInfoIntentProtocol,
+            model: model as InputTeacherInfoStateProtocol,
+            modelChangePublisher: model.objectWillChange
+        )
+        return InputTeacherInfoView(container: container)
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -24,4 +24,12 @@ final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
     func jobTitleSheetDismissed() {
         model?.updateIsPresentedJobTitleSheet(isPresented: false)
     }
+
+    func gradeSheetIsRequired() {
+        model?.updateIsPresentedGradeSheet(isPresented: true)
+    }
+
+    func gradeSheetDismissed() {
+        model?.updateIsPresentedGradeSheet(isPresented: false)
+    }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -3,8 +3,17 @@ import InputTeacherInfoFeatureInterface
 
 final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
     private weak var model: (any InputTeacherInfoActionProtocol)?
-    
-    init(model: any InputTeacherInfoActionProtocol) {
+    private weak var teacherDelegate: (any InputTeacherDelegate)?
+
+    init(
+        model: any InputTeacherInfoActionProtocol,
+        teacherDelegate: any InputTeacherDelegate
+    ) {
         self.model = model
+        self.teacherDelegate = teacherDelegate
+    }
+
+    func completeButtonDidTap() {
+        teacherDelegate?.completeToInputTeacherInformation()
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -1,3 +1,9 @@
 import Foundation
 
-final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {}
+final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
+    private weak var model: (any InputTeacherInfoActionProtocol)?
+    
+    init(model: any InputTeacherInfoActionProtocol) {
+        self.model = model
+    }
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import InputTeacherInfoFeatureInterface
 
 final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
     private weak var model: (any InputTeacherInfoActionProtocol)?

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -32,4 +32,12 @@ final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
     func gradeSheetDismissed() {
         model?.updateIsPresentedGradeSheet(isPresented: false)
     }
+
+    func classSheetIsRequired() {
+        model?.updateIsPresentedClassSheet(isPresented: true)
+    }
+
+    func classSheetDismissed() {
+        model?.updateIsPresentedClassSheet(isPresented: false)
+    }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntent.swift
@@ -16,4 +16,12 @@ final class InputTeacherInfoIntent: InputTeacherInfoIntentProtocol {
     func completeButtonDidTap() {
         teacherDelegate?.completeToInputTeacherInformation()
     }
+
+    func jobTitleSheetIsRequired() {
+        model?.updateIsPresentedJobTitleSheet(isPresented: true)
+    }
+
+    func jobTitleSheetDismissed() {
+        model?.updateIsPresentedJobTitleSheet(isPresented: false)
+    }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
@@ -2,4 +2,6 @@ import Foundation
 
 protocol InputTeacherInfoIntentProtocol {
     func completeButtonDidTap()
+    func jobTitleSheetIsRequired()
+    func jobTitleSheetDismissed()
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
@@ -1,3 +1,5 @@
 import Foundation
 
-protocol InputTeacherInfoIntentProtocol {}
+protocol InputTeacherInfoIntentProtocol {
+    func completeButtonDidTap()
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
@@ -4,4 +4,6 @@ protocol InputTeacherInfoIntentProtocol {
     func completeButtonDidTap()
     func jobTitleSheetIsRequired()
     func jobTitleSheetDismissed()
+    func gradeSheetIsRequired()
+    func gradeSheetDismissed()
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+protocol InputTeacherInfoIntentProtocol {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Intent/InputTeacherInfoIntentProtocol.swift
@@ -6,4 +6,6 @@ protocol InputTeacherInfoIntentProtocol {
     func jobTitleSheetDismissed()
     func gradeSheetIsRequired()
     func gradeSheetDismissed()
+    func classSheetIsRequired()
+    func classSheetDismissed()
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
@@ -1,3 +1,5 @@
 import Foundation
 
-final class InputTeacherInfoModel: ObservableObject {}
+final class InputTeacherInfoModel: ObservableObject, InputTeacherInfoStateProtocol {}
+
+extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
@@ -1,5 +1,11 @@
 import Foundation
 
-final class InputTeacherInfoModel: ObservableObject, InputTeacherInfoStateProtocol {}
+final class InputTeacherInfoModel: ObservableObject, InputTeacherInfoStateProtocol {
+    @Published var isPresentedJobTitleSheet: Bool = false
+}
 
-extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {}
+extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {
+    func updateIsPresentedJobTitleSheet(isPresented: Bool) {
+        self.isPresentedJobTitleSheet = isPresented
+    }
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
@@ -3,6 +3,7 @@ import Foundation
 final class InputTeacherInfoModel: ObservableObject, InputTeacherInfoStateProtocol {
     @Published var isPresentedJobTitleSheet: Bool = false
     @Published var isPresentedGradeSheet: Bool = false
+    @Published var isPresentedClassSheet: Bool = false
 }
 
 extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {
@@ -12,5 +13,9 @@ extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {
 
     func updateIsPresentedGradeSheet(isPresented: Bool) {
         self.isPresentedGradeSheet = isPresented
+    }
+
+    func updateIsPresentedClassSheet(isPresented: Bool) {
+        self.isPresentedClassSheet = isPresented
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
@@ -2,10 +2,15 @@ import Foundation
 
 final class InputTeacherInfoModel: ObservableObject, InputTeacherInfoStateProtocol {
     @Published var isPresentedJobTitleSheet: Bool = false
+    @Published var isPresentedGradeSheet: Bool = false
 }
 
 extension InputTeacherInfoModel: InputTeacherInfoActionProtocol {
     func updateIsPresentedJobTitleSheet(isPresented: Bool) {
         self.isPresentedJobTitleSheet = isPresented
+    }
+
+    func updateIsPresentedGradeSheet(isPresented: Bool) {
+        self.isPresentedGradeSheet = isPresented
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModel.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+final class InputTeacherInfoModel: ObservableObject {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -3,9 +3,11 @@ import Foundation
 protocol InputTeacherInfoStateProtocol {
     var isPresentedJobTitleSheet: Bool { get }
     var isPresentedGradeSheet: Bool { get }
+    var isPresentedClassSheet: Bool { get }
 }
 
 protocol InputTeacherInfoActionProtocol: AnyObject {
     func updateIsPresentedJobTitleSheet(isPresented: Bool)
     func updateIsPresentedGradeSheet(isPresented: Bool)
+    func updateIsPresentedClassSheet(isPresented: Bool)
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -2,8 +2,10 @@ import Foundation
 
 protocol InputTeacherInfoStateProtocol {
     var isPresentedJobTitleSheet: Bool { get }
+    var isPresentedGradeSheet: Bool { get }
 }
 
 protocol InputTeacherInfoActionProtocol: AnyObject {
     func updateIsPresentedJobTitleSheet(isPresented: Bool)
+    func updateIsPresentedGradeSheet(isPresented: Bool)
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol InputTeacherInfoStateProtocol {}
+ protocol InputTeacherInfoStateProtocol {}
 
 protocol InputTeacherInfoActionProtocol: AnyObject {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -1,5 +1,9 @@
 import Foundation
 
- protocol InputTeacherInfoStateProtocol {}
+protocol InputTeacherInfoStateProtocol {
+    var isPresentedJobTitleSheet: Bool { get }
+}
 
-protocol InputTeacherInfoActionProtocol: AnyObject {}
+protocol InputTeacherInfoActionProtocol: AnyObject {
+    func updateIsPresentedJobTitleSheet(isPresented: Bool)
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -2,4 +2,4 @@ import Foundation
 
 protocol InputTeacherInfoStateProtocol {}
 
-protocol InputTeacherInfoActionProtocol {}
+protocol InputTeacherInfoActionProtocol: AnyObject {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Model/InputTeacherInfoModelProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol InputTeacherInfoStateProtocol {}
+
+protocol InputTeacherInfoActionProtocol {}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -41,6 +41,15 @@ struct InputTeacherInfoView: View {
                     .onTapGesture {
                         intent.gradeSheetIsRequired()
                     }
+
+                    inputTeacherInfoTextField(
+                        title: "반",
+                        placeholder: "반 선택",
+                        text: .constant("")
+                    )
+                    .onTapGesture {
+                        intent.classSheetIsRequired()
+                    }
                 }
                 .padding(.top, 32)
 
@@ -66,6 +75,14 @@ struct InputTeacherInfoView: View {
             )
         ) {
             gradeListView()
+        }
+        .smsBottomSheet(
+            isShowing: Binding(
+                get: { state.isPresentedClassSheet},
+                set: { _ in intent.classSheetDismissed() }
+            )
+        ) {
+            classListView()
         }
     }
 
@@ -112,6 +129,25 @@ struct InputTeacherInfoView: View {
             ForEach(1..<4, id: \.self) { index in
                 HStack {
                     Text("\(index)학년")
+                        .smsFont(.body1, color: .neutral(.n50))
+
+                    Spacer()
+
+                    Circle()
+                        .fill(Color.sms(.primary(.p2)))
+                        .frame(width: 24, height: 24)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func classListView() -> some View {
+        VStack(spacing: 16) {
+            ForEach(1..<5, id: \.self) { index in
+                HStack {
+                    Text("\(index)반")
                         .smsFont(.body1, color: .neutral(.n50))
 
                     Spacer()

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct InputTeacherInfoView: View {
     @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
     var intent: any InputTeacherInfoIntentProtocol { container.intent }
-    var model: any InputTeacherInfoStateProtocol { container.model }
+    var state: any InputTeacherInfoStateProtocol { container.model }
 
     var body: some View {
         SMSNavigationTitleView(title: "정보입력") {
@@ -29,6 +29,9 @@ struct InputTeacherInfoView: View {
                         placeholder: "직함을 선택해 주세요.",
                         text: .constant("")
                     )
+                    .onTapGesture {
+                        intent.jobTitleSheetIsRequired()
+                    }
                 }
                 .padding(.top, 32)
 
@@ -38,6 +41,14 @@ struct InputTeacherInfoView: View {
                 Spacer()
             }
             .padding(.horizontal, 20)
+        }
+        .smsBottomSheet(
+            isShowing: Binding(
+                get: { state.isPresentedJobTitleSheet },
+                set: { _ in intent.jobTitleSheetDismissed() }
+            )
+        ) {
+            jobTitleListView()
         }
     }
 
@@ -57,5 +68,24 @@ struct InputTeacherInfoView: View {
                 .padding(.trailing, 12)
         }
         .titleWrapper(title)
+    }
+
+    @ViewBuilder
+    func jobTitleListView() -> some View {
+        VStack(spacing: 16) {
+            ForEach(0..<5, id: \.self) { index in
+                HStack {
+                    Text("\(index)")
+                        .smsFont(.body1, color: .neutral(.n50))
+
+                    Spacer()
+
+                    Circle()
+                        .fill(Color.sms(.primary(.p2)))
+                        .frame(width: 24, height: 24)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -1,12 +1,58 @@
 import BaseFeature
+import DesignSystem
+import InputInformationBaseFeature
 import SwiftUI
 
 struct InputTeacherInfoView: View {
-    @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
-    var intent: any InputTeacherInfoIntentProtocol { container.intent }
-    var state: any InputTeacherInfoStateProtocol { container.model }
-    
+
     var body: some View {
-        Text("Hello, World!")
+        SMSNavigationTitleView(title: "정보입력") {
+            VStack(spacing: 0) {
+                HStack(spacing: 4) {
+                    Text("프로필")
+                        .foregroundColor(.sms(.system(.black)))
+
+                    Text("*")
+                        .foregroundColor(.sms(.sub(.s2)))
+
+                    Spacer()
+                }
+                .smsFont(.title1)
+                .padding(.top, 36)
+
+                VStack(spacing: 24) {
+                    inputTeacherInfoTextField(
+                        title: "직함",
+                        placeholder: "직함을 선택해 주세요.",
+                        text: .constant("")
+                    )
+                }
+                .padding(.top, 32)
+
+                CTAButton(text: "완료")
+                    .padding(.top, 32)
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+
+    @ViewBuilder
+    func inputTeacherInfoTextField(
+        title: String,
+        placeholder: String,
+        text: Binding<String>
+    ) -> some View {
+        SMSTextField(
+            placeholder,
+            text: text
+        )
+        .disabled(true)
+        .overlay(alignment: .trailing) {
+            SMSIcon(.downChevron)
+                .padding(.trailing, 12)
+        }
+        .titleWrapper(title)
     }
 }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -5,7 +5,7 @@ struct InputTeacherInfoView: View {
     @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
     var intent: any InputTeacherInfoIntentProtocol { container.intent }
     var state: any InputTeacherInfoStateProtocol { container.model }
-
+    
     var body: some View {
         Text("Hello, World!")
     }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -1,11 +1,11 @@
 import BaseFeature
 import SwiftUI
 
-struct InputWorkInfoView: View {
+struct InputTeacherInfoView: View {
     @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
     var intent: any InputTeacherInfoIntentProtocol { container.intent }
     var state: any InputTeacherInfoStateProtocol { container.model }
-    
+
     var body: some View {
         Text("Hello, World!")
     }

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -26,11 +26,20 @@ struct InputTeacherInfoView: View {
                 VStack(spacing: 24) {
                     inputTeacherInfoTextField(
                         title: "직함",
-                        placeholder: "직함을 선택해 주세요.",
+                        placeholder: "직함 선택",
                         text: .constant("")
                     )
                     .onTapGesture {
                         intent.jobTitleSheetIsRequired()
+                    }
+
+                    inputTeacherInfoTextField(
+                        title: "학년",
+                        placeholder: "학년 선택",
+                        text: .constant("")
+                    )
+                    .onTapGesture {
+                        intent.gradeSheetIsRequired()
                     }
                 }
                 .padding(.top, 32)
@@ -49,6 +58,14 @@ struct InputTeacherInfoView: View {
             )
         ) {
             jobTitleListView()
+        }
+        .smsBottomSheet(
+            isShowing: Binding(
+                get: { state.isPresentedGradeSheet },
+                set: { _ in intent.gradeSheetDismissed() }
+            )
+        ) {
+            gradeListView()
         }
     }
 
@@ -76,6 +93,25 @@ struct InputTeacherInfoView: View {
             ForEach(0..<5, id: \.self) { index in
                 HStack {
                     Text("\(index)")
+                        .smsFont(.body1, color: .neutral(.n50))
+
+                    Spacer()
+
+                    Circle()
+                        .fill(Color.sms(.primary(.p2)))
+                        .frame(width: 24, height: 24)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func gradeListView() -> some View {
+        VStack(spacing: 16) {
+            ForEach(1..<4, id: \.self) { index in
+                HStack {
+                    Text("\(index)학년")
                         .smsFont(.body1, color: .neutral(.n50))
 
                     Spacer()

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -35,7 +35,7 @@ struct InputTeacherInfoView: View {
 
                     inputTeacherInfoTextField(
                         title: "학년",
-                        placeholder: "학년 선택",
+                        placeholder: "담당 학년 선택",
                         text: .constant("")
                     )
                     .onTapGesture {
@@ -44,7 +44,7 @@ struct InputTeacherInfoView: View {
 
                     inputTeacherInfoTextField(
                         title: "반",
-                        placeholder: "반 선택",
+                        placeholder: "담당 반 선택",
                         text: .constant("")
                     )
                     .onTapGesture {

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -1,0 +1,9 @@
+//
+//  InputTeacherInfoView.swift
+//  InputTeacherInfoFeatureInterface
+//
+//  Created by 정윤서 on 1/18/24.
+//  Copyright © 2024 com.msg. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -1,9 +1,12 @@
-//
-//  InputTeacherInfoView.swift
-//  InputTeacherInfoFeatureInterface
-//
-//  Created by 정윤서 on 1/18/24.
-//  Copyright © 2024 com.msg. All rights reserved.
-//
+import BaseFeature
+import SwiftUI
 
-import Foundation
+struct InputWorkInfoView: View {
+    @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
+    var intent: any InputTeacherInfoIntentProtocol { container.intent }
+    var state: any InputTeacherInfoStateProtocol { container.model }
+    
+    var body: some View {
+        Text("Hello, World!")
+    }
+}

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Scene/InputTeacherInfoView.swift
@@ -4,6 +4,9 @@ import InputInformationBaseFeature
 import SwiftUI
 
 struct InputTeacherInfoView: View {
+    @StateObject var container: MVIContainer<InputTeacherInfoIntentProtocol, InputTeacherInfoStateProtocol>
+    var intent: any InputTeacherInfoIntentProtocol { container.intent }
+    var model: any InputTeacherInfoStateProtocol { container.model }
 
     var body: some View {
         SMSNavigationTitleView(title: "정보입력") {

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Source.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Source.swift
@@ -1,1 +1,0 @@
-// This is for Tuist

--- a/Projects/Feature/InputTeacherInfoFeature/Sources/Source.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Sources/Source.swift
@@ -1,0 +1,1 @@
+// This is for Tuist

--- a/Projects/Feature/InputTeacherInfoFeature/Tests/InputTeacherInfoFeatureTest.swift
+++ b/Projects/Feature/InputTeacherInfoFeature/Tests/InputTeacherInfoFeatureTest.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class InputTeacherInfoFeatureTests: XCTestCase {
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testExample() {
+        XCTAssertEqual(1, 1)
+    }
+}


### PR DESCRIPTION
## 💡 개요
선생님 정보입력 페이지 UI를 추가했습니다.

## 📃 작업내용

https://github.com/GSM-MSG/SMS-iOS/assets/105629604/226dafa4-0075-4651-944e-1846032a66b1


## 🙋‍♂️ 질문사항
현재 선생님 정보입력 페이지는 선생님 계정으로 GAuth로그인을 하고 SMS 회원가입이 안 되어있을 때 띄워지는 View인데요!
그렇다면 제가 생각했을 때는 
1번 : RootFeature에 successToSignin에서 userRoleType에 따라 updateSceneType이 바뀌게 한다.
2번 : SigninDelegate에 학생로그인 선생님로그인으로 나누어서 SigninFeature에서 UseCase 호출을 한다.

2개 정도가 떠올랐는데요! API 명세서를 봤을 땐 1번이 더 맞을 거 같아 고민이 됩니다! 어떻게 하는 게 좋을까요?
 
## 🎸 기타
나중에 학년, 반 BottomSheet부분은 담임선생님을 선택했을 때 나타나도록 변경됩니다.

