### PR TITLE
🔀  :: [#336] SMSSegmentedControl 외부에서 selected option을 제어 가능하게 변경

### DIFF
--- a/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
+++ b/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
@@ -1,23 +1,26 @@
 import SwiftUI
 
 public struct SMSSegmentedControl: View {
-    @State private var selectedIndex = 0
     @Namespace private var segmentNamespace
     private let options: [String]
+    private let selectedOption: String?
     private let onSelect: (String) -> Void
 
     public init(
         options: [String],
+        selectedOption: String? = nil,
         onSelect: @escaping (String) -> Void
     ) {
         self.options = options
+        self.selectedOption = selectedOption
         self.onSelect = onSelect
     }
 
     public var body: some View {
         HStack(spacing: 0) {
             ForEach(0..<options.count, id: \.self) { index in
-                let isSelected = selectedIndex == index
+                let option = options[index]
+                let isSelected = options[index] == selectedOption
                 SMSText(options[index], font: .title2)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 9.5)
@@ -32,12 +35,12 @@ public struct SMSSegmentedControl: View {
                         }
                     }
                     .foregroundStyle(
-                        self.selectedIndex == index ? Color.sms(.system(.white)) : Color.sms(.neutral(.n40))
+                        isSelected ? Color.sms(.system(.white)) : Color.sms(.neutral(.n40))
                     )
                     .padding(4)
                     .buttonWrapper {
                         withAnimation(.interactiveSpring(duration: 0.5)) {
-                            self.selectedIndex = index
+                            onSelect(option)
                         }
                     }
             }

--- a/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
+++ b/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
@@ -49,7 +49,6 @@ public struct SMSSegmentedControl: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color.sms(.neutral(.n10)))
         }
-        .padding()
     }
 }
 

--- a/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
+++ b/Projects/Core/DesignSystem/Sources/SegmentedControl/SMSSegmentedControl.swift
@@ -18,10 +18,9 @@ public struct SMSSegmentedControl: View {
 
     public var body: some View {
         HStack(spacing: 0) {
-            ForEach(0..<options.count, id: \.self) { index in
-                let option = options[index]
-                let isSelected = options[index] == selectedOption
-                SMSText(options[index], font: .title2)
+            ForEach(options, id: \.self) { option in
+                let isSelected = option == selectedOption
+                SMSText(option, font: .title2)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 9.5)
                     .background {
@@ -51,4 +50,3 @@ public struct SMSSegmentedControl: View {
         }
     }
 }
-


### PR DESCRIPTION
## 💡 배경 및 개요

SMSSegmentedControl 외부에서 selected option을 제어 가능하게 변경

Resolves: #336 

## 📃 작업내용

- SMSSegmentedControl 파라미터에 selectedOption 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
